### PR TITLE
Fixed conflict with update-notifier-common

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Architecture: any
 Provides: update-notifier
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, dbus, procps, util-linux, libgtk2-perl
 Recommends: deepin-default-settings
+Replaces: update-notifier-common
 Description: daemon of lastore
  daemon of lastore - support dbus interface
 


### PR DESCRIPTION
Listed update-notifier-common as conflicting (=allow to write same files) because the file /usr/share/update-notifier/notify-reboot-required is provided by both packages.