### PR TITLE
feat: add DeepinTestSource

### DIFF
--- a/src/internal/system/common.go
+++ b/src/internal/system/common.go
@@ -124,6 +124,7 @@ const (
 	CustomSourceDir    = "/var/lib/lastore/sources.list.d"
 	OriginSourceDir    = "/etc/apt/sources.list.d"
 	SystemSourceFile   = "/etc/apt/sources.list"
+	DeepinTestSource   = "deepin-unstable-source.list"
 	AppStoreList       = "appstore.list"
 	AppStoreSourceFile = "/etc/apt/sources.list.d/" + AppStoreList
 	DriverList         = "driver.list"
@@ -171,7 +172,7 @@ func UpdateUnknownSourceDir() error {
 	for _, fileInfo := range sourceDirFileInfos {
 		name := fileInfo.Name()
 		if strings.HasSuffix(name, ".list") {
-			if name != AppStoreList && name != SecurityList && name != DriverList {
+			if name != AppStoreList && name != SecurityList && name != DriverList && name != DeepinTestSource {
 				unknownSourceFilePaths = append(unknownSourceFilePaths, filepath.Join(OriginSourceDir, name))
 			}
 		}

--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -79,12 +79,14 @@ var (
 		printerPath,
 		printerHelperPath,
 		langSelectorPath,
+		controlCenterPath,
 	}
 	allowRemovePackageExecPaths = strv.Strv{
 		appStoreDaemonPath,
 		oldAppStoreDaemonPath,
 		sessionDaemonPath,
 		langSelectorPath,
+		controlCenterPath,
 	}
 )
 


### PR DESCRIPTION
新开发了内测源相关的功能，新增了/etc/apt/sources.list.d/deepin-unstable-source.list的文件，社区版内测源非第三方仓库，因此将该仓库地址加入到默认的白名单内