### PR TITLE
fix: 修复watchUpdateInfo.path触发频率过高导致报错问题

### DIFF
--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -1639,6 +1639,7 @@ func (m *Manager) getLastoreSystemUnitMap() lastoreUnitMap {
 	}
 	unitMap["watchUpdateInfo"] = []string{
 		"--path-property=PathModified=/var/lib/lastore/update_infos.json",
+		"--property=StartLimitBurst=0",
 		"/bin/bash",
 		"-c",
 		fmt.Sprintf(`%s string:"%s"`, lastoreDBusCmd, "UpdateInfosChanged"), //监听update_infos.json文件


### PR DESCRIPTION
修改触发次数限制的默认值

Log: 修复watchUpdateInfo.path触发频率过高导致报错问题
Bug: https://pms.uniontech.com/bug-view-159517.html
Bug: https://pms.uniontech.com/bug-view-156721.html
Influence: 报错日志