### PR TITLE
fix: 控制中心无法接收内测源更新,移除相关提交

### DIFF
--- a/src/internal/system/common.go
+++ b/src/internal/system/common.go
@@ -124,7 +124,6 @@ const (
 	CustomSourceDir    = "/var/lib/lastore/sources.list.d"
 	OriginSourceDir    = "/etc/apt/sources.list.d"
 	SystemSourceFile   = "/etc/apt/sources.list"
-	DeepinTestSource   = "deepin-unstable-source.list"
 	AppStoreList       = "appstore.list"
 	AppStoreSourceFile = "/etc/apt/sources.list.d/" + AppStoreList
 	DriverList         = "driver.list"
@@ -172,7 +171,7 @@ func UpdateUnknownSourceDir() error {
 	for _, fileInfo := range sourceDirFileInfos {
 		name := fileInfo.Name()
 		if strings.HasSuffix(name, ".list") {
-			if name != AppStoreList && name != SecurityList && name != DriverList && name != DeepinTestSource {
+			if name != AppStoreList && name != SecurityList && name != DriverList {
 				unknownSourceFilePaths = append(unknownSourceFilePaths, filepath.Join(OriginSourceDir, name))
 			}
 		}


### PR DESCRIPTION
 控制中心无法接收内测源更新,移除后内测源默认走第三方仓库更新