### PR TITLE
fix: 修复上报更新平台信息无失败日志的问题

### DIFF
--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -883,12 +883,12 @@ func (m *Manager) createClassifiedUpgradeJob(sender dbus.Sender, updateType syst
 		job.next.setHooks(map[string]func(){
 			string(system.SucceedStatus): func() {
 				if m.needPostSystemUpgradeMessage() && updateType == system.SystemUpdate {
-					go m.postSystemUpgradeMessage(upgradeSucceed, job, updateType)
+					go m.postSystemUpgradeMessage(upgradeSucceed, job.next, updateType)
 				}
 			},
 			string(system.FailedStatus): func() {
 				if m.needPostSystemUpgradeMessage() && updateType == system.SystemUpdate {
-					go m.postSystemUpgradeMessage(upgradeFailed, job, updateType)
+					go m.postSystemUpgradeMessage(upgradeFailed, job.next, updateType)
 				}
 			},
 		})
@@ -1483,7 +1483,9 @@ func (m *Manager) postSystemUpgradeMessage(upgradeStatus int, j *Job, updateType
 	var upgradeErrorMsg string
 	var version string
 	if upgradeStatus == upgradeFailed {
-		upgradeErrorMsg = j.Description
+		if j != nil {
+			upgradeErrorMsg = j.Description
+		}
 		version = m.preUpgradeOSVersion
 	} else {
 		infoMap, err := getOSVersionInfo()


### PR DESCRIPTION
由于上报数据时使用的是下载任务的job，导致无法将安装失败的日志上报

Log: 修复上报更新平台信息无失败日志的问题
Bug: https://pms.uniontech.com/bug-view-168719.html
Influence: 上报数据