### PR TITLE
fix: 修复更新失败后再检查更新时，token中版本信息可能错误的问题

### DIFF
--- a/src/lastore-daemon/systeminfo_utils.go
+++ b/src/lastore-daemon/systeminfo_utils.go
@@ -11,8 +11,8 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
+	"github.com/linuxdeepin/go-lib/keyfile"
 	"internal/system"
 	"io/ioutil"
 	"os"
@@ -140,26 +140,31 @@ func loadFile(filepath string) ([]string, error) {
 
 func getOSVersionInfo() (map[string]string, error) {
 	versionPath := path.Join(etcDir, osVersionFileName)
-	versionLines, err := loadFile(versionPath)
+	kf := keyfile.NewKeyFile()
+	err := kf.LoadFromFile(versionPath)
 	if err != nil {
-		logger.Warning("failed to load os-version file:", err)
+		logger.Warning(err)
 		return nil, err
 	}
 	osVersionInfoMap := make(map[string]string)
-	for _, item := range versionLines {
-		itemSlice := strings.SplitN(item, "=", 2)
-		if len(itemSlice) < 2 {
-			continue
-		}
-		key := strings.TrimSpace(itemSlice[0])
-		value := strings.TrimSpace(itemSlice[1])
-		osVersionInfoMap[key] = value
-	}
-	// 判断必要内容是否存在
 	necessaryKey := []string{"SystemName", "ProductType", "EditionName", "MajorVersion", "MinorVersion", "OsBuild"}
+
 	for _, key := range necessaryKey {
-		if value := osVersionInfoMap[key]; value == "" {
-			return nil, errors.New("os-version lack necessary content")
+		osVersionInfoMap[key], err = kf.GetString("Version", key)
+		if err != nil {
+			logger.Warning(err)
+		}
+	}
+	if system.NormalFileExists(preVersionFilePath) {
+		versionKey := []string{"MajorVersion", "MinorVersion", "OsBuild"}
+		preVersionKf := keyfile.NewKeyFile()
+		err = preVersionKf.LoadFromFile(preVersionFilePath)
+		if err != nil {
+			logger.Warning(err)
+			return osVersionInfoMap, nil
+		}
+		for _, key := range versionKey {
+			osVersionInfoMap[key], err = preVersionKf.GetString("Version", key)
 		}
 	}
 	return osVersionInfoMap, nil


### PR DESCRIPTION
原因:更新失败时，可能os-version文件已经是最新的了，所以token文件的内容被更新了。
方案:更新失败时，将更新前系统版本进行保存，并更新token文件。

Log: 修复更新失败后再检查更新时，token中版本信息可能错误的问题
Bug: https://pms.uniontech.com/bug-view-169873.html
Influence: 更新平台上报数据