### PR TITLE
feat: 增加注册/注销agent接口

### DIFF
--- a/src/lastore-daemon/agent.go
+++ b/src/lastore-daemon/agent.go
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"internal/utils"
+	"io/ioutil"
+	"sync"
+
+	"github.com/godbus/dbus"
+	lastoreAgent "github.com/linuxdeepin/go-dbus-factory/com.deepin.lastore.agent"
+	login1 "github.com/linuxdeepin/go-dbus-factory/org.freedesktop.login1"
+	"github.com/linuxdeepin/go-lib/dbusutil"
+)
+
+const (
+	AutoCleanDone   = "AutoCleanDone"
+	AppRemove       = "AppRemove"
+	CanUpdate       = "CanUpdate"
+	AutoDownloading = "AutoDownloading"
+	CanUpgrade      = "CanUpgrade"
+	UpgradeFailed   = "UpgradeFailed"
+)
+
+const userAgentRecordPath = "/tmp/lastoreAgentCache"
+
+type userAgentMap struct {
+	mu         sync.Mutex
+	uidItemMap map[string]*sessionAgentMapItem // key 是 uid
+	activeUid  string
+}
+
+type sessionAgentMapItem struct {
+	sessions map[dbus.ObjectPath]login1.Session     // key 是 session 的路径
+	agents   map[dbus.ObjectPath]lastoreAgent.Agent // key 是 agent 的路径
+}
+
+func newUserAgentMap(service *dbusutil.Service) *userAgentMap {
+	u := recoverLastoreAgents(userAgentRecordPath, service)
+	if u != nil {
+		logger.Info("recover agent from", userAgentRecordPath)
+		return u
+	}
+	return &userAgentMap{
+		uidItemMap: make(map[string]*sessionAgentMapItem, 1),
+	}
+}
+
+func (m *userAgentMap) addAgent(uid string, agent lastoreAgent.Agent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	item, ok := m.uidItemMap[uid]
+	if ok {
+		if item.agents == nil {
+			item.agents = make(map[dbus.ObjectPath]lastoreAgent.Agent)
+		}
+		if len(item.agents) > 10 {
+			// 限制数量
+			return
+		}
+		item.agents[agent.Path_()] = agent
+	} else {
+		m.uidItemMap[uid] = &sessionAgentMapItem{
+			agents: map[dbus.ObjectPath]lastoreAgent.Agent{
+				agent.Path_(): agent,
+			},
+		}
+	}
+}
+
+func (m *userAgentMap) removeAgent(uid string, agentPath dbus.ObjectPath) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	item, ok := m.uidItemMap[uid]
+	if !ok {
+		return errors.New("invalid uid")
+	}
+
+	if _, ok := item.agents[agentPath]; ok {
+		return errors.New("invalid agent path")
+	}
+	delete(item.agents, agentPath)
+	return nil
+}
+
+func (m *userAgentMap) setActiveUid(uid string) {
+	logger.Info("active user's uid is", uid)
+	m.mu.Lock()
+	m.activeUid = uid
+	m.mu.Unlock()
+}
+
+func (m *userAgentMap) handleNameLost(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, item := range m.uidItemMap {
+		for path, agent := range item.agents {
+			if agent.ServiceName_() == name {
+				logger.Debug("remove agent", name, path)
+				delete(item.agents, path)
+			}
+		}
+	}
+}
+
+func (m *userAgentMap) addUser(uid string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.uidItemMap[uid]
+	if !ok {
+		m.uidItemMap[uid] = &sessionAgentMapItem{
+			sessions: make(map[dbus.ObjectPath]login1.Session),
+			agents:   make(map[dbus.ObjectPath]lastoreAgent.Agent),
+		}
+	}
+}
+
+func (m *userAgentMap) removeUser(uid string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	item, ok := m.uidItemMap[uid]
+	if !ok {
+		return
+	}
+
+	for sessionPath, session := range item.sessions {
+		session.RemoveAllHandlers()
+		delete(item.sessions, sessionPath)
+	}
+	delete(m.uidItemMap, uid)
+}
+
+func (m *userAgentMap) hasUser(uid string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.uidItemMap[uid]
+	return ok
+}
+
+func (m *userAgentMap) addSession(uid string, session login1.Session) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	item, ok := m.uidItemMap[uid]
+	if !ok {
+		return false
+	}
+
+	_, ok = item.sessions[session.Path_()]
+	if ok {
+		return false
+	}
+	item.sessions[session.Path_()] = session
+	return true
+}
+
+func (m *userAgentMap) removeSession(sessionPath dbus.ObjectPath) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, item := range m.uidItemMap {
+		for sPath, session := range item.sessions {
+			if sPath == sessionPath {
+				session.RemoveAllHandlers()
+				delete(item.sessions, sPath)
+			}
+		}
+	}
+}
+
+const lastoreAgentPath = "/com/deepin/lastore/agent"
+
+func (m *userAgentMap) getActiveLastoreAgent() lastoreAgent.Agent {
+	return m.getActiveAgent(lastoreAgentPath)
+}
+
+func (m *userAgentMap) getActiveAgent(path dbus.ObjectPath) lastoreAgent.Agent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.activeUid == "" {
+		return nil
+	}
+
+	item := m.uidItemMap[m.activeUid]
+	if item == nil {
+		return nil
+	}
+	return item.agents[path]
+}
+
+type sessionAgentMapInfo struct {
+	Sessions []dbus.ObjectPath          // key 是 session 的路径
+	Agents   map[dbus.ObjectPath]string // key 是 agent 的路径, value 是agent 的serviceName(即sender)
+}
+
+// userAgentInfoMap 用来持久化数据,数据来源是userAgentMap
+type userAgentInfoMap struct {
+	ActiveUid  string
+	UidInfoMap map[string]*sessionAgentMapInfo // key 是 uid
+}
+
+// 将userAgentMap数据转换为json字符串，供lastore闲时退出时保存
+func (m *userAgentMap) getAgentsInfo() *userAgentInfoMap {
+	infoMap := &userAgentInfoMap{
+		ActiveUid:  m.activeUid,
+		UidInfoMap: make(map[string]*sessionAgentMapInfo),
+	}
+	for uid, item := range m.uidItemMap {
+		var sessions []dbus.ObjectPath
+		agentsMap := make(map[dbus.ObjectPath]string)
+		for sessionPath, _ := range item.sessions {
+			sessions = append(sessions, sessionPath)
+		}
+		for agentPath, agent := range item.agents {
+			agentsMap[agentPath] = agent.ServiceName_()
+		}
+		infoMap.UidInfoMap[uid] = &sessionAgentMapInfo{
+			Sessions: sessions,
+			Agents:   agentsMap,
+		}
+	}
+	return infoMap
+}
+
+// 将agent数据序列化成JSON格式写入recordFilePath中
+func (m *userAgentMap) saveRecordContent(recordFilePath string) {
+	err := utils.WriteData(recordFilePath, m.getAgentsInfo())
+	if err != nil {
+		logger.Warning(err)
+	}
+}
+
+// 根据配置文件，恢复之前注册的Agents数据
+func recoverLastoreAgents(recordFilePath string, service *dbusutil.Service) *userAgentMap {
+	var infoMap userAgentInfoMap
+	var agentMap userAgentMap
+	err := decodeJson(recordFilePath, &infoMap)
+	if err != nil {
+		logger.Warning(err)
+		return nil
+	}
+	agentMap.activeUid = infoMap.ActiveUid
+	for uid, uidInfo := range infoMap.UidInfoMap {
+		var item sessionAgentMapItem
+		agentMap.uidItemMap = make(map[string]*sessionAgentMapItem)
+		item.sessions = make(map[dbus.ObjectPath]login1.Session)
+		item.agents = make(map[dbus.ObjectPath]lastoreAgent.Agent)
+		for _, sessionPath := range uidInfo.Sessions {
+			session, err := login1.NewSession(service.Conn(), sessionPath)
+			if err != nil {
+				logger.Warning(err)
+				continue
+			}
+			item.sessions[sessionPath] = session
+		}
+		for agentPath, agentSender := range uidInfo.Agents {
+			agent, err := lastoreAgent.NewAgent(service.Conn(), agentSender, agentPath)
+			if err != nil {
+				logger.Warning(err)
+				continue
+			}
+			item.agents[agentPath] = agent
+		}
+
+		agentMap.uidItemMap[uid] = &item
+	}
+	return &agentMap
+}
+
+func decodeJson(fpath string, d interface{}) error {
+	content, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(content, &d)
+}

--- a/src/lastore-daemon/exported_methods_auto.go
+++ b/src/lastore-daemon/exported_methods_auto.go
@@ -86,6 +86,11 @@ func (v *Manager) GetExportedMethods() dbusutil.ExportedMethods {
 			OutArgs: []string{"job"},
 		},
 		{
+			Name:   "RegisterAgent",
+			Fn:     v.RegisterAgent,
+			InArgs: []string{"path"},
+		},
+		{
 			Name:    "RemovePackage",
 			Fn:      v.RemovePackage,
 			InArgs:  []string{"jobName", "packages"},
@@ -105,6 +110,11 @@ func (v *Manager) GetExportedMethods() dbusutil.ExportedMethods {
 			Name:   "StartJob",
 			Fn:     v.StartJob,
 			InArgs: []string{"jobId"},
+		},
+		{
+			Name:   "UnRegisterAgent",
+			Fn:     v.UnRegisterAgent,
+			InArgs: []string{"path"},
 		},
 		{
 			Name:    "UpdatePackage",

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"strconv"
+
+	"github.com/godbus/dbus"
+	agent "github.com/linuxdeepin/go-dbus-factory/com.deepin.lastore.agent"
+	login1 "github.com/linuxdeepin/go-dbus-factory/org.freedesktop.login1"
+	"github.com/linuxdeepin/go-lib/dbusutil"
+)
+
+func (m *Manager) RegisterAgent(sender dbus.Sender, path dbus.ObjectPath) *dbus.Error {
+	logger.Info("RegisterAgent:", path)
+	uid, err := m.service.GetConnUID(string(sender))
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+	uidStr := strconv.Itoa(int(uid))
+	m.userAgents.addUser(uidStr)
+
+	sessionDetails, err := m.loginManager.ListSessions(0)
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+	sysBus := m.service.Conn()
+	for _, detail := range sessionDetails {
+		if detail.UID == uid {
+			session, err := login1.NewSession(sysBus, detail.Path)
+			if err != nil {
+				logger.Warning(err)
+				continue
+			}
+			newlyAdded := m.userAgents.addSession(uidStr, session)
+			if newlyAdded {
+				m.watchSession(uidStr, session)
+			}
+		}
+	}
+
+	a, err := agent.NewAgent(m.service.Conn(), string(sender), path)
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+	m.userAgents.addAgent(uidStr, a)
+	return nil
+}
+
+func (m *Manager) UnRegisterAgent(sender dbus.Sender, path dbus.ObjectPath) *dbus.Error {
+	uid, err := m.service.GetConnUID(string(sender))
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+
+	uidStr := strconv.Itoa(int(uid))
+	err = m.userAgents.removeAgent(uidStr, path)
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+	logger.Debugf("agent unregistered, sender: %q, agentPath: %q", sender, path)
+	return nil
+}

--- a/usr/share/dbus-1/system.d/com.deepin.lastore.conf
+++ b/usr/share/dbus-1/system.d/com.deepin.lastore.conf
@@ -10,6 +10,7 @@
     <allow own="com.deepin.lastore"/>
     <allow send_destination="com.deepin.lastore"/>
     <allow receive_sender="com.deepin.lastore"/>
+    <allow send_interface="com.deepin.lastore.agent"/>
   </policy>
 
   <policy context="default">


### PR DESCRIPTION
lastore-daemon定义一套agent接口,由dde-daemon的lastore模块实现相关接口并导出,需要发通知和需要获取系统代理时,lastore-daemon调用agent接口完成.

Log: 增加注册/注销agent接口
Task: https://pms.uniontech.com/task-view-214983.html
Influence: 增加agent机制