### PR TITLE
fix: 修复内测源被识别为第三方仓库

### DIFF
--- a/src/internal/system/common.go
+++ b/src/internal/system/common.go
@@ -165,7 +165,7 @@ func UpdateUnknownSourceDir() error {
 		AppStoreList,
 		SecurityList,
 		DriverList,
-		UnstableSourceFile,
+		UnstableSourceList,
 		HweSourceList,
 	}
 	for _, fileInfo := range sourceDirFileInfos {


### PR DESCRIPTION
 变量使用错误导致内测源被识别为第三方仓库

Log: 修复内测源被识别为第三方仓库
Bug: https://pms.uniontech.com/bug-view-172585.html
Influence: 系统更新 内测源更新