### PR TITLE
chore: Release 6.1.0.0 version

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,7 +4,7 @@ Upstream-Contact: UnionTech Software Technology Co., Ltd.  <>
 Source: https://github.com/linuxdeepin/lastore-daemon
 
 # gitignore clang-format gitreview .tx
-Files: .gitignore .clang-format .gitreview .mailmap .tx/config
+Files: .gitignore .clang-format .gitreview .mailmap .tx/config .tx/deepin.conf
 Copyright: None
 License: CC0-1.0
 

--- a/.tx/deepin.conf
+++ b/.tx/deepin.conf
@@ -1,0 +1,1 @@
+[transifex]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lastore-daemon (6.1.0.0) stable; urgency=medium
+
+  * 集成到obs构建
+
+ -- myml <wurongjie@deepin.com>  Thu, 6 Apr 2023 14:10:00 +0800
+
 lastore-daemon (6.0.5.1) stable; urgency=medium
 
   [ TagBuilder ]


### PR DESCRIPTION
发布6.1.0.0版本,用于集成deepin v23

Log: