### PR TITLE
chore: add legacy AM daemon compat service to allowlist

### DIFF
--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -61,8 +61,9 @@ const (
 	langSelectorPath      = "/usr/lib/deepin-daemon/langselector"
 	controlCenterPath     = "/usr/bin/dde-control-center"
 	controlCenterCmdLine  = "/usr/share/applications/dde-control-center.deskto" // 缺个 p 是因为 deepin-turbo 修改命令的时候 buffer 不够用, 所以截断了.
-	amDaemonPath = "/usr/bin/dde-application-manager"
+	amDaemonPath          = "/usr/bin/dde-application-manager"
 	launcherPath          = "/usr/bin/dde-launcher"
+	amDaemonCompatPath    = "/usr/libexec/dde-application-wizard-daemon-compat"
 )
 
 var (
@@ -82,6 +83,7 @@ var (
 		controlCenterPath,
 		amDaemonPath,
 		launcherPath,
+		amDaemonCompatPath,
 	}
 )
 


### PR DESCRIPTION
添加旧AM接口兼容服务到卸载接口的白名单列表中。