### PR TITLE
fix: cannot start smart mirror service

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -33,3 +33,6 @@ endif
 
 override_dh_installsystemd:
 	dh_installsystemd -r --no-restart-after-upgrade --no-start
+
+execute_after_dh_installinit:
+	dh_installsysusers

--- a/lib/systemd/system/lastore-smartmirror-daemon.service
+++ b/lib/systemd/system/lastore-smartmirror-daemon.service
@@ -7,7 +7,7 @@ After=dbus.socket
 [Service]
 Type=dbus
 BusName=org.deepin.dde.Lastore1.Smartmirror
-User=deepin-daemon
+User=lastore-daemon
 ExecStart=/usr/libexec/lastore-daemon/lastore-smartmirror-daemon
 StandardOutput=null
 StandardError=journal


### PR DESCRIPTION
用户不存在导致服务无法启动