### PR TITLE
fix: 解决智能镜像源配置不生效的问题

### DIFF
--- a/etc/apt/apt.conf.d/99lastore.conf
+++ b/etc/apt/apt.conf.d/99lastore.conf
@@ -5,7 +5,7 @@ DPkg::Post-Invoke { "/var/lib/lastore/scripts/build_system_info || true "}
 Acquire::SmartMirrors::Enable true;
 Acquire::SmartMirrors::Debug false;
 Acquire::SmartMirrors::GuestURI "/usr/bin/lastore-smartmirror";
-Acquire::SmartMirrors::MainSource "http://packages.chinauos.cn/uos";
+Acquire::SmartMirrors::MainSource "https://cdn-community-packages.deepin.com/deepin";
 Acquire::SmartMirrors::DomainList:: "deepin.com";
 Acquire::SmartMirrors::DomainList:: "deepin.org";
 Acquire::SmartMirrors::DomainList:: "uniontech.com";

--- a/etc/apt/apt.conf.d/99mirrors.conf
+++ b/etc/apt/apt.conf.d/99mirrors.conf
@@ -1,3 +1,3 @@
 #Don't wirte anything except MirrorSource, otherwise the config may lost
 
-Acquire::SmartMirrors::MirrorSource "http://cdn.packages.deepin.com/deepin";
+Acquire::SmartMirrors::MirrorSource "https://cdn-community-packages.deepin.com/deepin";

--- a/src/lastore-smartmirror-daemon/smartmirror.go
+++ b/src/lastore-smartmirror-daemon/smartmirror.go
@@ -126,13 +126,17 @@ func (s *SmartMirror) route(original, officialMirror string) string {
 		return original
 	}
 
-	if strings.HasPrefix(original, officialMirror+"/pool") {
+	if !strings.HasPrefix(original, officialMirror) {
+		return original
+	}
+
+	if strings.Contains(original, "/pool/") {
 		return s.makeChoice(original, officialMirror)
-	} else if strings.HasPrefix(original, officialMirror+"/dists") && strings.HasSuffix(original, "Release") {
+	} else if strings.Contains(original, "/dists/") && strings.HasSuffix(original, "Release") {
 		// Get Release from Release
 		url, _ := handleRequest(buildRequest(makeHeader(), "HEAD", original))
 		return url
-	} else if strings.HasPrefix(original, officialMirror+"/dists") && strings.Contains(original, "/by-hash/") {
+	} else if strings.Contains(original, "/dists/") && strings.Contains(original, "/by-hash/") {
 		return s.makeChoice(original, officialMirror)
 	}
 	return original

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -2,7 +2,7 @@
   {
     "id": "default",
     "name": "Official Mirror (CDN Acceleration)",
-    "url": "http://cdn.packages.deepin.com/deepin/",
+    "url": "https://cdn-community-packages.deepin.com/deepin",
     "name_locale": {
       "zh_CN": "官方CDN（加速）源",
       "zh_TW": "官方CDN（加速）源"


### PR DESCRIPTION
cdn服务器地址不正确，导致匹配不到

Log: 解决智能镜像源配置不生效的问题
pms: BUG-302185