### PR TITLE
fix: 解决系统启动时lastore的自启动的一些服务运行失败的问题

### DIFF
--- a/src/lastore-daemon/exported_methods_auto.go
+++ b/src/lastore-daemon/exported_methods_auto.go
@@ -41,6 +41,11 @@ func (v *Manager) GetExportedMethods() dbusutil.ExportedMethods {
 			OutArgs: []string{"info"},
 		},
 		{
+			Name:   "HandleSystemEvent",
+			Fn:     v.HandleSystemEvent,
+			InArgs: []string{"eventType"},
+		},
+		{
 			Name:    "InstallPackage",
 			Fn:      v.InstallPackage,
 			InArgs:  []string{"jobName", "packages"},

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -89,7 +89,7 @@ func (m *Manager) GetArchivesInfo() (info string, busErr *dbus.Error) {
 	return info, nil
 }
 
-func (m *Manager) handleSystemEvent(sender dbus.Sender, eventType string) *dbus.Error {
+func (m *Manager) HandleSystemEvent(sender dbus.Sender, eventType string) *dbus.Error {
 	return dbusutil.ToError(m.delHandleSystemEvent(sender, eventType))
 }
 


### PR DESCRIPTION
由于之前去掉了一些暂时没有用到的接口，但是这些失败的服务调用其中的一个接口，现在将这个接口添加回去

Log: 解决系统启动时lastore的自启动的一些服务运行失败的问题
pms: BUG-303841