### PR TITLE
fix: Update only after successful backup

### DIFF
--- a/src/lastore-daemon/manager_upgrade.go
+++ b/src/lastore-daemon/manager_upgrade.go
@@ -161,7 +161,7 @@ func (m *Manager) distUpgradePartly(sender dbus.Sender, origin system.UpdateType
 			},
 		})
 		backupJob.setAfterHooks(map[string]func() error{
-			string(system.EndStatus): func() error {
+			string(system.SucceedStatus): func() error {
 				startJobErr = startUpgrade()
 				if startJobErr != nil {
 					logger.Warning(err)


### PR DESCRIPTION
原有的EndStatus状态包含备份失败场景, 备份失败时不应该执行更新流程

pms: BUG-314657