### PR TITLE
fix: 修复环境变量设置方式，确保在执行命令时正确传递环境变量

### DIFF
--- a/src/lastore-daemon/manager_upgrade.go
+++ b/src/lastore-daemon/manager_upgrade.go
@@ -11,8 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
-	"github.com/linuxdeepin/lastore-daemon/src/internal/system/dut"
 	"net/url"
 	"os"
 	"os/exec"
@@ -21,6 +19,9 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
+	"github.com/linuxdeepin/lastore-daemon/src/internal/system/dut"
 
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/updateplatform"
@@ -548,7 +549,7 @@ func (m *Manager) preFailedHook(job *Job, mode system.UpdateType, uuid string) e
 func osTreeCmd(args []string) (out string, err error) {
 	if system.NormalFileExists(DEEPIN_IMMUTABLE_CTL) {
 		cmd := exec.Command(DEEPIN_IMMUTABLE_CTL, args...) // #nosec G204
-		cmd.Env = append(cmd.Env, "IMMUTABLE_DISABLE_REMOUNT=false")
+		cmd.Env = append(os.Environ(), "IMMUTABLE_DISABLE_REMOUNT=false")
 		logger.Info("run command:", cmd.Args)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout

--- a/src/lastore-tools/upgradable.go
+++ b/src/lastore-tools/upgradable.go
@@ -9,8 +9,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
-	"github.com/linuxdeepin/lastore-daemon/src/internal/system/apt"
 	"io"
 	"os"
 	"os/exec"
@@ -18,6 +16,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
+	"github.com/linuxdeepin/lastore-daemon/src/internal/system/apt"
 )
 
 func buildUpgradeInfoRegex(archs []system.Architecture) *regexp.Regexp {
@@ -109,7 +110,7 @@ func queryDpkgUpgradeInfoByAptList(sourcePath string) ([]string, error) {
 	}
 	args = append(args, []string{"list", "--upgradable"}...)
 	cmd := exec.Command("apt", append(args, ps...)...) // #nosec G204
-	cmd.Env = append(cmd.Env, "IMMUTABLE_DISABLE_REMOUNT=true")
+	cmd.Env = append(os.Environ(), "IMMUTABLE_DISABLE_REMOUNT=true")
 	r, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -144,7 +145,7 @@ func queryDpkgUpgradeInfoByAptList(sourcePath string) ([]string, error) {
 
 func getSystemArchitectures() []system.Architecture {
 	cmd := exec.Command("dpkg", "--print-foreign-architectures")
-	cmd.Env = append(cmd.Env, "IMMUTABLE_DISABLE_REMOUNT=true")
+	cmd.Env = append(os.Environ(), "IMMUTABLE_DISABLE_REMOUNT=true")
 	foreignArchs, err := cmd.Output()
 	if err != nil {
 		logger.Warningf("GetSystemArchitecture failed:%v\n", foreignArchs)


### PR DESCRIPTION
更新了`manager_upgrade.go`和`upgradable.go`文件中的环境变量设置方式，使用`os.Environ()`替代原有的方式，以确保在执行命令时能够正确传递环境变量`IMMUTABLE_DISABLE_REMOUNT`。

pms: TASK-368711