### PR TITLE
fix: check if dpkg supports --script-ignore-error

### DIFF
--- a/src/lastore-daemon/manager_upgrade.go
+++ b/src/lastore-daemon/manager_upgrade.go
@@ -284,7 +284,7 @@ func (m *Manager) distUpgrade(sender dbus.Sender, mode system.UpdateType, isClas
 			job.option["Dir::State::lists"] = system.OfflineListPath
 		}
 
-		if mode == system.UnknownUpdate {
+		if m.supportDpkgScriptIgnore && mode == system.UnknownUpdate {
 			job.option["DPkg::Options::"] = "--script-ignore-error"
 		}
 


### PR DESCRIPTION
Ensure the correct handling of script ignore error options under specific conditions.

pms: BUG-320601