### PR TITLE
feat: Prohibit checking for updates when automatic restore is enabled

### DIFF
--- a/src/lastore-daemon/dbusutil.go
+++ b/src/lastore-daemon/dbusutil.go
@@ -429,3 +429,16 @@ func (v *Manager) setPropHardwareId(value string) (changed bool) {
 func (v *Manager) emitPropChangedHardwareId(value string) error {
 	return v.service.EmitPropertyChanged(v, "HardwareId", value)
 }
+
+func (v *Manager) setPropImmutableAutoRecovery(value bool) (changed bool) {
+	if v.ImmutableAutoRecovery != value {
+		v.ImmutableAutoRecovery = value
+		v.emitPropChangedImmutableAutoRecovery(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedImmutableAutoRecovery(value bool) error {
+	return v.service.EmitPropertyChanged(v, "ImmutableAutoRecovery", value)
+}

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -54,6 +54,12 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 	if !system.IsAuthorized() {
 		return nil, errors.New("not authorized, don't allow to exec update")
 	}
+
+	if m.ImmutableAutoRecovery {
+		logger.Info("immutable auto recovery is enabled, don't allow to exec update")
+		return nil, errors.New("immutable auto recovery is enabled, don't allow to exec update")
+	}
+
 	defer func() {
 		if err == nil {
 			err1 := m.config.UpdateLastCheckTime()


### PR DESCRIPTION
After enabling automatic restore, updates are invalid, so checking for updates is directly prohibited

pms: TASK-378055