### PR TITLE
fix: disable auto updates in immutable recovery mode

### DIFF
--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -1215,6 +1215,11 @@ func (m *Manager) updateAutoRecoveryStatus() {
 	isEnabled := string(bootedContent) == "overlay"
 	if isEnabled {
 		logger.Info("immutable auto recovery is enabled")
+		// 在无忧还原模式下，主动停止相关定时器
+		_ = m.stopTimerUnit(lastoreAutoCheck)
+		_ = m.stopTimerUnit(lastoreOnline)
+		_ = m.stopTimerUnit(lastoreAutoDownload)
+		_ = m.stopTimerUnit(lastoreAbortAutoDownload)
 	} else {
 		logger.Info("immutable auto recovery is disabled")
 	}

--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -23,6 +23,10 @@ import (
 
 // prepareDistUpgrade isClassify true: mode只能是单类型,创建一个单类型的下载job; false: mode类型不限,创建一个全mode类型的下载job
 func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateType, isClassify bool) (*Job, error) {
+	if m.ImmutableAutoRecovery {
+		logger.Info("immutable auto recovery is enabled, don't allow to exec prepareDistUpgrade")
+		return nil, errors.New("immutable auto recovery is enabled, don't allow to exec prepareDistUpgrade")
+	}
 	if !system.IsAuthorized() {
 		return nil, errors.New("not authorized, don't allow to exec download")
 	}


### PR DESCRIPTION
1. Added checks for ImmutableAutoRecovery flag in prepareDistUpgrade, updateAutoDownloadTimer and refreshUpdateInfos functions
2. When immutable recovery is enabled, blocks distribution upgrades, auto download timer updates and automatic updates
3. Stops existing timers when in recovery mode to prevent unwanted updates
4. This change ensures system stability in recovery mode by preventing modifications that could interfere with the recovery process

fix: 在不可变恢复模式下禁用自动更新

1. 在prepareDistUpgrade、updateAutoDownloadTimer和refreshUpdateInfos函数 中添加了对ImmutableAutoRecovery标志的检查
2. 当不可变恢复模式启用时，阻止分发升级、自动下载计时器更新和自动更新
3. 在恢复模式下停止现有计时器以防止不必要的更新
4. 此更改通过防止可能干扰恢复过程的修改来确保恢复模式下系统的稳定性