### PR TITLE
fix: update error message formatting for disk space notifications

### DIFF
--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -82,7 +82,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 			ErrDetail:    "You don't have enough free space to download",
 			IsCheckError: true,
 		}
-		msg := fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %g GB disk space first."), needDownloadSize/(1000*1000*1000))
+		msg := fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %n GB disk space first."), needDownloadSize/(1000*1000*1000))
 		go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, nil, nil, system.NotifyExpireTimeoutNoHide)
 		logger.Warning(dbusError.Error())
 		errStr, _ := json.Marshal(dbusError)
@@ -173,7 +173,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 							logger.Warning(err)
 							size = needDownloadSize
 						}
-						msg = fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %g GB disk space first."), size/(1000*1000*1000))
+						msg = fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %n GB disk space first."), size/(1000*1000*1000))
 						go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, nil, nil, system.NotifyExpireTimeoutDefault)
 					} else if strings.Contains(errorContent.ErrType.String(), system.ErrorDamagePackage.String()) {
 						// 下载更新失败，需要apt-get clean后重新下载


### PR DESCRIPTION
Changed the format specifier in the error messages for insufficient disk space during updates from %g to %n to ensure proper localization and display of the required disk space in gigabytes.

pms: BUG-317395