### PR TITLE
fix: update error message format for disk space notifications

### DIFF
--- a/locale/ady.po
+++ b/locale/ady.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/af.po
+++ b/locale/af.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ak.po
+++ b/locale/ak.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/am_ET.po
+++ b/locale/am_ET.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ar_EG.po
+++ b/locale/ar_EG.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ast.po
+++ b/locale/ast.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/az.po
+++ b/locale/az.po
@@ -71,9 +71,9 @@ msgstr "Yenilənmələr yoxlanılır və quraşdırılır..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"Yenilənmələrin endirilməsi mümkün olmadı. Öncə %n QB disk sahəsini "
+"Yenilənmələrin endirilməsi mümkün olmadı. Öncə %g QB disk sahəsini "
 "təmizləyin."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -72,7 +72,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/bn.po
+++ b/locale/bn.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/bo.po
+++ b/locale/bo.po
@@ -68,8 +68,8 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "གསར་སྒྱུར་ཁུག་མ་ཕབ་ལེན་བྱེད་མ་ཐུབ། བར་སྟོང་%nGBགློད་རོགས།"
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "གསར་སྒྱུར་ཁུག་མ་ཕབ་ལེན་བྱེད་མ་ཐུབ། བར་སྟོང་%gGBགློད་རོགས།"
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/bqi.po
+++ b/locale/bqi.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/br.po
+++ b/locale/br.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -70,9 +70,9 @@ msgstr "Es comproven i s'instal·len actualitzacions..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"No s'han pogut baixar les actualitzacions. Si us plau, allibereu %n GB "
+"No s'han pogut baixar les actualitzacions. Si us plau, allibereu %g GB "
 "d'espai al disc primer."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/cgg.po
+++ b/locale/cgg.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -70,9 +70,9 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"Stažení aktualizací se nezdařilo. Nejprve prosím uvolněte %n GB místa na "
+"Stažení aktualizací se nezdařilo. Nejprve prosím uvolněte %g GB místa na "
 "disku."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/da.po
+++ b/locale/da.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/de.po
+++ b/locale/de.po
@@ -71,10 +71,10 @@ msgstr "Aktualisierungen werden geprüft und installiert ..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 "Herunterladen von Aktualisierungen ist fehlgeschlagen. Bitte geben Sie "
-"zuerst %n GB Speicherplatz frei."
+"zuerst %g GB Speicherplatz frei."
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/de_CH.po
+++ b/locale/de_CH.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -68,9 +68,9 @@ msgstr "Prüfen und installieren der Aktualisierungen…"
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"Herunterladen der Aktualisierungen schlug fehl, bitte zuerst %n GB "
+"Herunterladen der Aktualisierungen schlug fehl, bitte zuerst %g GB "
 "Festplattenplatz frei machen."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/el.po
+++ b/locale/el.po
@@ -73,7 +73,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/en_AU.po
+++ b/locale/en_AU.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/en_GB.po
+++ b/locale/en_GB.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -68,8 +68,8 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "Downloading updates failed. Please free up %g GB disk space first."
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/eo.po
+++ b/locale/eo.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/es.po
+++ b/locale/es.po
@@ -75,9 +75,9 @@ msgstr "Comprobando e instalando actualizaciones..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"La descarga de actualizaciones falló. Primero libere %n GB de espacio en "
+"La descarga de actualizaciones falló. Primero libere %g GB de espacio en "
 "disco."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/et.po
+++ b/locale/et.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/eu.po
+++ b/locale/eu.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/fa.po
+++ b/locale/fa.po
@@ -72,7 +72,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -71,8 +71,8 @@ msgstr "Päivityksiä tarkistetaan ja asennetaan..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "Päivitysten lataaminen epäonnistui. Vapauta ensin %n Gt levytilaa."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "Päivitysten lataaminen epäonnistui. Vapauta ensin %g Gt levytilaa."
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -73,7 +73,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/gl_ES.po
+++ b/locale/gl_ES.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/he.po
+++ b/locale/he.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/hi_IN.po
+++ b/locale/hi_IN.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -71,9 +71,9 @@ msgstr "Ellenőrzés, és frissítések telepítése..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"A frissítések letöltése nem sikerült. Kérjük először szabadítson fel %n GB "
+"A frissítések letöltése nem sikerült. Kérjük először szabadítson fel %g GB "
 "lemezterületet."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/hy.po
+++ b/locale/hy.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/id.po
+++ b/locale/id.po
@@ -73,7 +73,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/it.po
+++ b/locale/it.po
@@ -69,8 +69,8 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "Download aggioranamenti fallito, libera almeno %n GB sul disco."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "Download aggioranamenti fallito, libera almeno %g GB sul disco."
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -73,7 +73,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/kab.po
+++ b/locale/kab.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/kk.po
+++ b/locale/kk.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/km_KH.po
+++ b/locale/km_KH.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/kn_IN.po
+++ b/locale/kn_IN.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ku.po
+++ b/locale/ku.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ku_IQ.po
+++ b/locale/ku_IQ.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ky.po
+++ b/locale/ky.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ky@Arab.po
+++ b/locale/ky@Arab.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/la.po
+++ b/locale/la.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/lastore-daemon.pot
+++ b/locale/lastore-daemon.pot
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/lo.po
+++ b/locale/lo.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -70,7 +70,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/lv.po
+++ b/locale/lv.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ml.po
+++ b/locale/ml.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/mn.po
+++ b/locale/mn.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/mr.po
+++ b/locale/mr.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ms.po
+++ b/locale/ms.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -72,7 +72,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ne.po
+++ b/locale/ne.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -71,9 +71,9 @@ msgstr "Bezig met afhandelen van updates…"
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"De updates kunnen niet worden gedownload. Maak minimaal %n GB schijfruimte "
+"De updates kunnen niet worden gedownload. Maak minimaal %g GB schijfruimte "
 "vrij en probeer het opnieuw."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/pa.po
+++ b/locale/pa.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/pam.po
+++ b/locale/pam.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -73,9 +73,9 @@ msgstr "Sprawdzanie i instalowanie aktualizacji..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"Błąd pobierania aktualizacji. Najpierw zwolnij %n GB miejsca na dysku."
+"Błąd pobierania aktualizacji. Najpierw zwolnij %g GB miejsca na dysku."
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/ps.po
+++ b/locale/ps.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -72,7 +72,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -74,9 +74,9 @@ msgstr "Verificando e instalando as atualizações..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"O download das atualizações falhou. Primeiro, libere %n GB de espaço em "
+"O download das atualizações falhou. Primeiro, libere %g GB de espaço em "
 "disco."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -75,7 +75,7 @@ msgstr "Проверка и установка обновлений..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/sc.po
+++ b/locale/sc.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/si.po
+++ b/locale/si.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/sl.po
+++ b/locale/sl.po
@@ -72,7 +72,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/sq.po
+++ b/locale/sq.po
@@ -68,9 +68,9 @@ msgstr "Po kontrollohet për përditësime dhe po instalohen…"
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"Shkarkimi i përditësimeve dështoi. Ju lutemi, së pari, lironi %n GB hapësirë"
+"Shkarkimi i përditësimeve dështoi. Ju lutemi, së pari, lironi %g GB hapësirë"
 " në disk."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/sr.po
+++ b/locale/sr.po
@@ -72,7 +72,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/sw.po
+++ b/locale/sw.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ta.po
+++ b/locale/ta.po
@@ -69,7 +69,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/te.po
+++ b/locale/te.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/th.po
+++ b/locale/th.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -74,9 +74,9 @@ msgstr "Güncellemeleri kontrol ediliyor ve yükleniyor ..."
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"Güncellemeleri indirme başarısız oldu. Lütfen önce %n GB disk alanını "
+"Güncellemeleri indirme başarısız oldu. Lütfen önce %g GB disk alanını "
 "boşaltın."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/tzm.po
+++ b/locale/tzm.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ug.po
+++ b/locale/ug.po
@@ -73,8 +73,8 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "يېڭىلاش بولىقىنى چۈشۈرۈش مەغلۇب بولدى، GB%n بوشلۇق بىكارلاڭ"
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "يېڭىلاش بولىقىنى چۈشۈرۈش مەغلۇب بولدى، GB%g بوشلۇق بىكارلاڭ"
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -71,9 +71,9 @@ msgstr "Шукаємо і встановлюємо оновлення…"
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
-"Не вдалося отримати оновлення. Будь ласка, звільніть на диску принаймні %n "
+"Не вдалося отримати оновлення. Будь ласка, звільніть на диску принаймні %g "
 "ГБ."
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/ur.po
+++ b/locale/ur.po
@@ -64,7 +64,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/uz.po
+++ b/locale/uz.po
@@ -68,7 +68,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -71,7 +71,7 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
+msgid "Downloading updates failed. Please free up %g GB disk space first."
 msgstr ""
 
 #: ../src/lastore-daemon/manager_download.go:136

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -71,8 +71,8 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "更新包下载失败，请释放%n GB空间"
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "更新包下载失败，请释放%g GB空间"
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/zh_HK.po
+++ b/locale/zh_HK.po
@@ -70,8 +70,8 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "更新包下載失敗，請釋放%n GB空間"
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "更新包下載失敗，請釋放%g GB空間"
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -72,8 +72,8 @@ msgstr ""
 #: ../src/lastore-daemon/manager_download.go:78
 #: ../src/lastore-daemon/manager_download.go:172
 #, c-format
-msgid "Downloading updates failed. Please free up %n GB disk space first."
-msgstr "更新包下載失敗，請釋放%n GB空間"
+msgid "Downloading updates failed. Please free up %g GB disk space first."
+msgstr "更新包下載失敗，請釋放%g GB空間"
 
 #: ../src/lastore-daemon/manager_download.go:136
 msgid "New version available! Downloading..."

--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -82,7 +82,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 			ErrDetail:    "You don't have enough free space to download",
 			IsCheckError: true,
 		}
-		msg := fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %n GB disk space first."), needDownloadSize/(1000*1000*1000))
+		msg := fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %g GB disk space first."), needDownloadSize/(1000*1000*1000))
 		go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, nil, nil, system.NotifyExpireTimeoutNoHide)
 		logger.Warning(dbusError.Error())
 		errStr, _ := json.Marshal(dbusError)
@@ -173,7 +173,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 							logger.Warning(err)
 							size = needDownloadSize
 						}
-						msg = fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %n GB disk space first."), size/(1000*1000*1000))
+						msg = fmt.Sprintf(gettext.Tr("Downloading updates failed. Please free up %g GB disk space first."), size/(1000*1000*1000))
 						go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, nil, nil, system.NotifyExpireTimeoutDefault)
 					} else if strings.Contains(errorContent.ErrType.String(), system.ErrorDamagePackage.String()) {
 						// 下载更新失败，需要apt-get clean后重新下载


### PR DESCRIPTION
Changed the format specifier in the error messages for insufficient disk space during updates from %n to %g to ensure proper localization and display of the required disk space in gigabytes.

pms: BUG-317395