### PR TITLE
fix: Issues related to idle-time downloading

### DIFF
--- a/lib/systemd/system/lastore-abort-auto-download.service
+++ b/lib/systemd/system/lastore-abort-auto-download.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=System Update Auto Download Abort Service
+Wants=lastore-daemon.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/dbus-send --system --print-reply --dest=org.deepin.dde.Lastore1 /org/deepin/dde/Lastore1 org.deepin.dde.Lastore1.Manager.HandleSystemEvent string:AbortAutoDownload

--- a/lib/systemd/system/lastore-auto-download.service
+++ b/lib/systemd/system/lastore-auto-download.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=System Update Auto Download Service
+Wants=lastore-daemon.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/dbus-send --system --print-reply --dest=org.deepin.dde.Lastore1 /org/deepin/dde/Lastore1 org.deepin.dde.Lastore1.Manager.HandleSystemEvent string:AutoDownload

--- a/src/lastore-daemon/common_test.go
+++ b/src/lastore-daemon/common_test.go
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2018 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseAutoDownloadTime(t *testing.T) {
+	// now is 2025-08-20 12:00:00
+	now := time.Date(2025, 8, 20, 12, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name           string
+		hourMinute     string
+		expectError    bool
+		expectDateTime string
+	}{
+		// Valid cases
+		{
+			name:           "valid time 00:00, before now",
+			hourMinute:     "00:00",
+			expectError:    false,
+			expectDateTime: "2025-08-20 00:00:00",
+		},
+		{
+			name:           "valid time 12:30, after now",
+			hourMinute:     "12:30",
+			expectError:    false,
+			expectDateTime: "2025-08-20 12:30:00",
+		},
+		{
+			name:           "valid time 23:59, after now",
+			hourMinute:     "23:59",
+			expectError:    false,
+			expectDateTime: "2025-08-20 23:59:00",
+		},
+		{
+			name:           "valid time 09:05, before now",
+			hourMinute:     "09:05",
+			expectError:    false,
+			expectDateTime: "2025-08-20 09:05:00",
+		},
+		{
+			name:           "single digit hour",
+			hourMinute:     "9:30",
+			expectError:    false,
+			expectDateTime: "2025-08-20 09:30:00",
+		},
+		// Invalid cases
+		{
+			name:        "invalid format without colon",
+			hourMinute:  "1230",
+			expectError: true,
+		},
+		{
+			name:        "invalid format with seconds",
+			hourMinute:  "12:30:45",
+			expectError: true,
+		},
+		{
+			name:        "invalid hour 24",
+			hourMinute:  "24:00",
+			expectError: true,
+		},
+		{
+			name:        "invalid minute 60",
+			hourMinute:  "12:60",
+			expectError: true,
+		},
+		{
+			name:        "invalid hour negative",
+			hourMinute:  "-1:30",
+			expectError: true,
+		},
+		{
+			name:        "invalid minute negative",
+			hourMinute:  "12:-5",
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			hourMinute:  "",
+			expectError: true,
+		},
+		{
+			name:        "invalid format single digit minute",
+			hourMinute:  "09:5",
+			expectError: true,
+		},
+		{
+			name:        "invalid characters",
+			hourMinute:  "ab:cd",
+			expectError: true,
+		},
+		{
+			name:        "invalid format with space",
+			hourMinute:  "12: 30",
+			expectError: true,
+		},
+		{
+			name:        "invalid format with extra characters",
+			hourMinute:  "12:30am",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseAutoDownloadTime(tt.hourMinute, now)
+			t.Log("result: ", result)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none for input %q", tt.hourMinute)
+				}
+				// Check that zero time is returned on error
+				if !result.IsZero() {
+					t.Errorf("expected zero time on error but got %v", result)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for input %q: %v", tt.hourMinute, err)
+				}
+
+				dt := result.Format(time.DateTime)
+				if dt != tt.expectDateTime {
+					t.Errorf("expected date time %s but got %s for input %q", tt.expectDateTime, dt, tt.hourMinute)
+				}
+
+				// Check that seconds are 0 (since we only parse hour:minute)
+				if result.Second() != 0 {
+					t.Errorf("expected second to be 0 but got %d for input %q", result.Second(), tt.hourMinute)
+				}
+			}
+		})
+	}
+}
+
+func TestParseAutoDownloadRange(t *testing.T) {
+	// now is 2025-08-20 12:00:00
+	now := time.Date(2025, 8, 20, 12, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name        string
+		config      idleDownloadConfig
+		expectError bool
+		expectStart string
+		expectEnd   string
+	}{
+		// Normal cases - begin time before end time
+		{
+			name: "normal range morning to afternoon",
+			config: idleDownloadConfig{
+				BeginTime: "09:00",
+				EndTime:   "17:00",
+			},
+			expectError: false,
+			expectStart: "2025-08-20 09:00:00",
+			expectEnd:   "2025-08-20 17:00:00",
+		},
+		{
+			name: "normal range early morning",
+			config: idleDownloadConfig{
+				BeginTime: "02:30",
+				EndTime:   "06:45",
+			},
+			expectError: false,
+			expectStart: "2025-08-20 02:30:00",
+			expectEnd:   "2025-08-20 06:45:00",
+		},
+		{
+			name: "same begin and end time",
+			config: idleDownloadConfig{
+				BeginTime: "12:00",
+				EndTime:   "12:00",
+			},
+			expectError: false,
+			expectStart: "2025-08-20 12:00:00",
+			expectEnd:   "2025-08-20 12:00:00",
+		},
+		// Cross midnight cases - begin time after end time
+		{
+			name: "cross midnight evening to morning",
+			config: idleDownloadConfig{
+				BeginTime: "23:00",
+				EndTime:   "03:00",
+			},
+			expectError: false,
+			expectStart: "2025-08-20 23:00:00",
+			expectEnd:   "2025-08-21 03:00:00", // next day
+		},
+		{
+			name: "cross midnight late night to early morning",
+			config: idleDownloadConfig{
+				BeginTime: "22:30",
+				EndTime:   "05:15",
+			},
+			expectError: false,
+			expectStart: "2025-08-20 22:30:00",
+			expectEnd:   "2025-08-21 05:15:00", // next day
+		},
+		{
+			name: "cross midnight just after midnight",
+			config: idleDownloadConfig{
+				BeginTime: "23:59",
+				EndTime:   "00:01",
+			},
+			expectError: false,
+			expectStart: "2025-08-20 23:59:00",
+			expectEnd:   "2025-08-21 00:01:00", // next day
+		},
+		// Error cases - invalid begin time
+		{
+			name: "invalid begin time format",
+			config: idleDownloadConfig{
+				BeginTime: "invalid",
+				EndTime:   "17:00",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid begin time hour",
+			config: idleDownloadConfig{
+				BeginTime: "25:00",
+				EndTime:   "17:00",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty begin time",
+			config: idleDownloadConfig{
+				BeginTime: "",
+				EndTime:   "17:00",
+			},
+			expectError: true,
+		},
+		// Error cases - invalid end time
+		{
+			name: "invalid end time format",
+			config: idleDownloadConfig{
+				BeginTime: "09:00",
+				EndTime:   "invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid end time minute",
+			config: idleDownloadConfig{
+				BeginTime: "09:00",
+				EndTime:   "17:60",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty end time",
+			config: idleDownloadConfig{
+				BeginTime: "09:00",
+				EndTime:   "",
+			},
+			expectError: true,
+		},
+		// Error cases - both times invalid
+		{
+			name: "both times invalid",
+			config: idleDownloadConfig{
+				BeginTime: "invalid",
+				EndTime:   "also_invalid",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseAutoDownloadRange(tt.config, now)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none for config %+v", tt.config)
+				}
+				// Check that zero TimeRange is returned on error
+				if !result.Start.IsZero() || !result.End.IsZero() {
+					t.Errorf("expected zero TimeRange on error but got %v", result)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for config %+v: %v", tt.config, err)
+				}
+
+				startStr := result.Start.Format(time.DateTime)
+				if startStr != tt.expectStart {
+					t.Errorf("expected start time %s but got %s for config %+v", tt.expectStart, startStr, tt.config)
+				}
+
+				endStr := result.End.Format(time.DateTime)
+				if endStr != tt.expectEnd {
+					t.Errorf("expected end time %s but got %s for config %+v", tt.expectEnd, endStr, tt.config)
+				}
+
+				// Verify that the TimeRange was created correctly
+				if result.Start.After(result.End) {
+					t.Errorf("start time should not be after end time in result: start=%v, end=%v", result.Start, result.End)
+				}
+			}
+		})
+	}
+}

--- a/src/lastore-daemon/job.go
+++ b/src/lastore-daemon/job.go
@@ -63,7 +63,19 @@ type Job struct {
 	updateTyp system.UpdateType
 
 	errLogPath []string
+
+	initiator Initiator // source of trigger
 }
+
+// Initiator is the source of trigger
+type Initiator uint
+
+const (
+	// initiatorUser User manually triggered
+	initiatorUser Initiator = iota
+	// initiatorAuto Automatically triggered
+	initiatorAuto
+)
 
 func NewJob(service *dbusutil.Service, id, jobName string, packages []string, jobType, queueName string, environ map[string]string) *Job {
 	j := &Job{

--- a/src/lastore-daemon/main.go
+++ b/src/lastore-daemon/main.go
@@ -152,6 +152,11 @@ func main() {
 	}
 	manager.PropsMu.RUnlock()
 	manager.startOfflineTask()
+	// Ensure that the systemd timer configuration is consistent with the current configuration.
+	err = updater.applyIdleDownloadConfig(updater.idleDownloadConfigObj, time.Time{}, true)
+	if err != nil {
+		logger.Warning("failed to apply idle download config at startup:", err)
+	}
 	logger.Info("Started service at system bus")
 	autoQuitTime := 60 * time.Second
 	if logger.GetLogLevel() == log.LevelDebug {

--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -110,8 +110,6 @@ type Manager struct {
 	checkDpkgCapabilityOnce sync.Once
 	supportDpkgScriptIgnore bool
 
-	resetIdleDownload bool
-
 	logFds     []*os.File
 	logFdsMu   sync.Mutex
 	logTmpFile *os.File
@@ -145,7 +143,6 @@ func NewManager(service *dbusutil.Service, updateApi system.System, c *config.Co
 		abObj:                abrecovery.NewABRecovery(service.Conn()),
 		securitySourceConfig: make(UpdateSourceConfig),
 		systemSourceConfig:   make(UpdateSourceConfig),
-		resetIdleDownload:    true,
 	}
 	m.reloadOemConfig(true)
 	m.signalLoop.Start()
@@ -1129,8 +1126,6 @@ func (m *Manager) updateAutoRecoveryStatus() {
 		// 在无忧还原模式下，主动停止相关定时器
 		_ = m.stopTimerUnit(lastoreAutoCheck)
 		_ = m.stopTimerUnit(lastoreOnline)
-		_ = m.stopTimerUnit(lastoreAutoDownload)
-		_ = m.stopTimerUnit(lastoreAbortAutoDownload)
 	} else {
 		logger.Info("immutable auto recovery is disabled")
 	}

--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -21,7 +21,7 @@ import (
 	"github.com/linuxdeepin/go-lib/gettext"
 )
 
-func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateType) (*Job, error) {
+func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateType, initiator Initiator) (*Job, error) {
 	if m.ImmutableAutoRecovery {
 		logger.Info("immutable auto recovery is enabled, don't allow to exec prepareDistUpgrade")
 		return nil, errors.New("immutable auto recovery is enabled, don't allow to exec prepareDistUpgrade")
@@ -112,6 +112,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 	if isExist {
 		return job, nil
 	}
+	job.initiator = initiator
 	currentJob := job
 	var sendDownloadingOnce sync.Once
 	// 遍历job和所有next

--- a/src/lastore-daemon/manager_idle.go
+++ b/src/lastore-daemon/manager_idle.go
@@ -85,7 +85,7 @@ func (m *Manager) loadCacheJob() {
 				continue
 			}
 		case system.PausedStatus:
-			_, err := m.prepareDistUpgrade(dbus.Sender(m.service.Conn().Names()[0]), m.CheckUpdateMode)
+			_, err := m.prepareDistUpgrade(dbus.Sender(m.service.Conn().Names()[0]), m.CheckUpdateMode, initiatorAuto)
 			if err != nil {
 				logger.Warning(err)
 				return
@@ -162,13 +162,10 @@ func (m *Manager) inhibitAutoQuitCountAdd() {
 
 func (m *Manager) loadLastoreCache() {
 	m.loadUpdateSourceOnce()
-	m.loadResetIdleDownload()
-	// m.loadCacheJob()
 }
 
 func (m *Manager) saveLastoreCache() {
 	m.saveUpdateSourceOnce()
-	m.saveResetIdleDownload()
 	m.userAgents.saveRecordContent(userAgentRecordPath)
 }
 

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -486,7 +486,7 @@ func (m *Manager) QueryAllSizeWithSource(mode system.UpdateType) (int64, *dbus.E
 
 func (m *Manager) PrepareDistUpgradePartly(sender dbus.Sender, mode system.UpdateType) (job dbus.ObjectPath, busErr *dbus.Error) {
 	m.service.DelayAutoQuit()
-	jobObj, err := m.prepareDistUpgrade(sender, mode)
+	jobObj, err := m.prepareDistUpgrade(sender, mode, initiatorUser)
 	if err != nil {
 		logger.Warning(err)
 		return "/", dbusutil.ToError(err)

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -503,7 +503,7 @@ func (m *Manager) refreshUpdateInfos(sync bool) {
 		go func() {
 			m.inhibitAutoQuitCountAdd()
 			logger.Info("auto download force updates")
-			_, err := m.prepareDistUpgrade(dbus.Sender(m.service.Conn().Names()[0]), system.SystemUpdate) // TODO system.SystemUpdate
+			_, err := m.prepareDistUpgrade(dbus.Sender(m.service.Conn().Names()[0]), system.SystemUpdate, initiatorAuto) // TODO system.SystemUpdate
 			if err != nil {
 				logger.Error("failed to prepare dist-upgrade:", err)
 			}
@@ -527,7 +527,7 @@ func (m *Manager) refreshUpdateInfos(sync bool) {
 		logger.Info("auto download updates")
 		go func() {
 			m.inhibitAutoQuitCountAdd()
-			_, err := m.prepareDistUpgrade(dbus.Sender(m.service.Conn().Names()[0]), m.CheckUpdateMode)
+			_, err := m.prepareDistUpgrade(dbus.Sender(m.service.Conn().Names()[0]), m.CheckUpdateMode, initiatorAuto)
 			if err != nil {
 				logger.Error("failed to prepare dist-upgrade:", err)
 			}


### PR DESCRIPTION
* Use a persistent timer file instead of a transient one.
    * Differentiate between automatic and manually triggered
     downloads; only stop automatic downloads when idle-time
     downloading finishes.
    * 11 minutes after startup, check if the current time
     falls within the idle-time downloading window, and if
     so, start automatic downloading.

* 使用永久 timer 文件替代 transient 的 timer。
* 区分自动下载和手动触发下载，只在闲时下载结束时停止自动下载。
* 开机后11分钟，检查现在是否处于闲时下载时间区间内，如果处于则开始自动下载。

    Log: 修复闲时下载相关问题
    Bug: Bug-317329, Bug-317345, Bug-321655