### PR TITLE
feat: Adding authentication to the lastore-daemon installation interface

### DIFF
--- a/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
+++ b/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
@@ -68,6 +68,17 @@
       "permissions": "readwrite",
       "visibility": "private"
     },
+    "install-package-support-auth": {
+      "value": true,
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "InstallPackageSupportAuth",
+      "description": "",
+      "permissions": "readonly",
+      "visibility": "private"
+    },
     "mirror-source": {
       "value": "default",
       "serial": 0,


### PR DESCRIPTION
为了逐步替换白名单功能，安装接口InstallPackage给第三方使用，判断在白名单外的非root调用，先进行管理员鉴权，鉴权成功后继续执行后续逻辑。

Log: InstallPackage接口加上鉴权弹窗
Task: https://pms.uniontech.com/task-view-381841.html
Influence: 影响非root用户调用InstallPackage接口