### PR TITLE
fix: Upgrade failed due to missing lastore-update-tools executable

### DIFF
--- a/usr/bin/lastore-update-tools
+++ b/usr/bin/lastore-update-tools
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Compatible with upgrade from lastore-daemon 6.2.30
+echo '{"Code":0}'


### PR DESCRIPTION
Add the lastore-update-tools shell script, which always executes
successfully.
pms: BUG-336013
