### PR TITLE
fix: unify system upgrade logic

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -800,6 +800,10 @@ func (c *Config) SetIncrementalUpdate(enable bool) error {
 	return c.save(dSettingsKeyIncrementalUpdate, enable)
 }
 
+func (c *Config) UseIncrementalUpdate() bool {
+	return !c.IntranetUpdate && c.IncrementalUpdate
+}
+
 func (c *Config) SetMirrorSource(id string) error {
 	c.MirrorSource = id
 	return c.save(dSettingsKeyMirrorSource, id)

--- a/src/lastore-apt-clean/main.go
+++ b/src/lastore-apt-clean/main.go
@@ -78,7 +78,7 @@ func main() {
 
 	// 如果是增量更新，则调用deepin-immutable-ctl upgrade cleanup命令清理immutable系统的缓存deb包和ostree包分支
 	cfg := config.NewConfig(path.Join("/var/lib/lastore", "config.json"))
-	if cfg.IncrementalUpdate {
+	if cfg.UseIncrementalUpdate() {
 		err := exec.Command("deepin-immutable-ctl", "upgrade", "clean").Run()
 		if err != nil {
 			logger.Debugf("failed to clean upgrade cache: %v", err)

--- a/src/lastore-daemon/main.go
+++ b/src/lastore-daemon/main.go
@@ -85,7 +85,7 @@ func main() {
 		}()
 	}
 
-	aptImpl := dut.NewSystem(config.NonUnknownList, config.OtherSourceList, config.IncrementalUpdate)
+	aptImpl := dut.NewSystem(config.NonUnknownList, config.OtherSourceList, config.UseIncrementalUpdate())
 	system.SetSystemUpdate(config.PlatformUpdate) // 设置是否通过平台更新
 	allowInstallPackageExecPaths = append(allowInstallPackageExecPaths, config.AllowInstallRemovePkgExecPaths...)
 	allowRemovePackageExecPaths = append(allowRemovePackageExecPaths, config.AllowInstallRemovePkgExecPaths...)

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -214,7 +214,7 @@ func (m *Manager) PackagesDownloadSize(packages []string) (int64, *dbus.Error) {
 		logger.Warningf("PackagesDownloadSize(%q)=%0.2f %v\n", strings.Join(packages, " "), size, err)
 	}
 
-	if m.config.IncrementalUpdate && size > 0 && apt.IsIncrementalUpdateCached("") {
+	if m.config.UseIncrementalUpdate() && size > 0 && apt.IsIncrementalUpdateCached("") {
 		size = 0.0
 	}
 

--- a/src/lastore-daemon/update_status.go
+++ b/src/lastore-daemon/update_status.go
@@ -441,7 +441,7 @@ func (m *UpdateModeStatusManager) updateModeStatusBySize(mode system.UpdateType,
 						sourceArgs = "-o Dir::Etc::sourcelist=" + sourceList + " -o Dir::Etc::SourceParts=/dev/null"
 					}
 				}
-				if m.lsConfig.IncrementalUpdate && needDownloadSize > 0 && apt.IsIncrementalUpdateCached(sourceArgs) {
+				if m.lsConfig.UseIncrementalUpdate() && needDownloadSize > 0 && apt.IsIncrementalUpdateCached(sourceArgs) {
 					needDownloadSize = 0.0
 				}
 

--- a/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
+++ b/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
@@ -510,7 +510,7 @@
       "visibility": "private"
     },
     "upgrade-delivery-enabled": {
-      "value": true,
+      "value": false,
       "serial": 0,
       "flags": [
         "global"
@@ -612,7 +612,7 @@
       "visibility": "private"
     },
     "incremental-update": {
-      "value": false,
+      "value": true,
       "serial": 0,
       "flags": [
         "global"


### PR DESCRIPTION
Only enable incremental update when
- intranet-update is false
- incremental-update is true

Task: https://pms.uniontech.com/task-view-387631.html