### PR TITLE
fix: Speed limit logic failure.

### DIFF
--- a/src/internal/ratelimit/ratelimit.go
+++ b/src/internal/ratelimit/ratelimit.go
@@ -37,8 +37,8 @@ type IPFSConfig struct {
 	UploadLimit   *SyncLimit `json:"ul"` // 上传限速
 }
 
-const MaxRate = 1024 * 1024 * 100 // 最大速率(100 MB/s)
-const MinRate = 1024 * 1024       // 最小速率(1 MB/s)
+const MaxRate = 999999 * 1024 // 最大速率(999999 KB/s)
+const MinRate = 10 * 1024     // 最小速率(10 KB/s)
 
 const (
 	RateLimitTypeNo     = 0 // 表示不设置

--- a/src/internal/system/apt/proxy.go
+++ b/src/internal/system/apt/proxy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
 )
 
-const aptLimitKey = "Acquire::http::Dl-Limit"
+const aptHttpLimitKey = "Acquire::http::Dl-Limit"
 const aptSourcePartsKey = "Dir::Etc::SourceParts"
 const aptSourceListKey = "Dir::Etc::SourceList"
 
@@ -336,7 +336,7 @@ func (p *APTSystem) DownloadSource(jobId string, packages []string, environ map[
 
 	if p.IncrementalUpdate {
 		var cmdArgs []string
-		speedLimit, ok := args[aptLimitKey]
+		speedLimit, ok := args[aptHttpLimitKey]
 		if ok {
 			cmdArgs = append(cmdArgs, "--max-recv-speed", speedLimit)
 		}
@@ -401,7 +401,7 @@ func (p *APTSystem) DistUpgrade(jobId string, packages []string, environ map[str
 	if p.IncrementalUpdate {
 		logger.Info("incremental update")
 		var cmdArgs []string
-		speedLimit, ok := args[aptLimitKey]
+		speedLimit, ok := args[aptHttpLimitKey]
 		if ok {
 			cmdArgs = append(cmdArgs, "--max-recv-speed", speedLimit)
 		}

--- a/src/internal/updateplatform/message_report.go
+++ b/src/internal/updateplatform/message_report.go
@@ -739,7 +739,14 @@ func (m *UpdatePlatformManager) genIpfsConfigResponse() (*http.Response, error) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %v: %w", uri, err)
 	}
-	uri = uri.JoinPath(Urls[GetIPFSConfig].path)
+	parentPath := filepath.Dir(uri.Path)
+	if parentPath == "." {
+		parentPath = "/"
+	}
+	uri.Path = parentPath
+
+	// ipfs限速配置的路由需要使用p2p-boot前缀来替换requestUrl部分的最后一个路径段
+	uri = uri.JoinPath("p2p-boot", Urls[GetIPFSConfig].path)
 
 	q := uri.Query()
 	q.Set("id", m.IPFSConfig.ID)
@@ -2207,6 +2214,7 @@ func (m *UpdatePlatformManager) CheckPolicyChanged() (bool, error) {
 	oldSum, _ := m.getCheckPolicyCache()
 
 	if oldSum != newSum {
+		logger.Infof("CheckPolicyChanged: oldSum=%s, newSum=%s", oldSum, newSum)
 		m.saveCheckPolicyCache(newSum)
 		return true, nil
 	}

--- a/src/lastore-daemon/common.go
+++ b/src/lastore-daemon/common.go
@@ -386,7 +386,10 @@ func cleanAllCache() {
 	}
 }
 
-const aptLimitKey = "Acquire::http::Dl-Limit"
+// source.list协议使用了delivery后，需要适用Acquire::delivery::Dl-Limit来进行限速，但是delivery有回退到http协议的机制，
+// 所以为了避免回退后限速失效，我们需要同时设置Acquire::http::Dl-Limit和Acquire::delivery::Dl-Limit
+const aptHttpLimitKey = "Acquire::http::Dl-Limit"
+const aptDeliveryLimitKey = "Acquire::delivery::Dl-Limit"
 
 const upgradeRecordPath = "/var/cache/lastore/upgrade_record.json"
 

--- a/src/lastore-daemon/job_manager.go
+++ b/src/lastore-daemon/job_manager.go
@@ -390,11 +390,13 @@ func (jm *JobManager) dispatch() {
 
 			if job.option != nil {
 				// 上一个job无论是否存在该配置，都需要传递给下一个job
-				v, ok := job.option[aptLimitKey]
-				if ok {
-					job.next.option[aptLimitKey] = v
-				} else {
-					delete(job.next.option, aptLimitKey)
+				for _, limitKey := range []string{aptHttpLimitKey, aptDeliveryLimitKey} {
+					v, ok := job.option[limitKey]
+					if ok {
+						job.next.option[limitKey] = v
+					} else {
+						delete(job.next.option, limitKey)
+					}
 				}
 			}
 			job = job.next

--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -1119,10 +1119,12 @@ func (m *Manager) handleDownloadLimitChanged(job *Job) {
 		if job.option == nil {
 			job.option = make(map[string]string)
 		}
-		job.option[aptLimitKey] = limitConfig
+		job.option[aptHttpLimitKey] = limitConfig
+		job.option[aptDeliveryLimitKey] = limitConfig
 	} else {
 		if job.option != nil {
-			delete(job.option, aptLimitKey)
+			delete(job.option, aptHttpLimitKey)
+			delete(job.option, aptDeliveryLimitKey)
 		}
 	}
 }

--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -248,7 +248,8 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 		limitEnable, limitConfig, limitIsOnline := m.updater.GetLimitConfig()
 		logger.Infof("preDistUpgrade limitEnable: %v, limitConfig: %v, limitIsOnline: %v", limitEnable, limitConfig, limitIsOnline)
 		if limitEnable || limitIsOnline {
-			j.option[aptLimitKey] = limitConfig
+			j.option[aptHttpLimitKey] = limitConfig
+			j.option[aptDeliveryLimitKey] = limitConfig
 		}
 		j.subRetryHookFn = func(job *Job) {
 			// 下载限速的配置修改需要在job失败重试的时候修改配置(此处失败为手动终止设置的失败状态)

--- a/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
+++ b/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
@@ -634,6 +634,162 @@
       "description": "update from intranet update platform",
       "permissions": "readonly",
       "visibility": "private"
+    },
+    "delivery-remote-download-global-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryRemoteDownloadGlobalLimit",
+      "name[zh_CN]": "远程下载全局限速",
+      "description[zh_CN]": "传递优化远程下载全局限速配置",
+      "description": "Delivery remote download global limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-remote-upload-global-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryRemoteUploadGlobalLimit",
+      "name[zh_CN]": "远程上传全局限速",
+      "description[zh_CN]": "传递优化远程上传全局限速配置",
+      "description": "Delivery remote upload global limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-remote-download-peak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryRemoteDownloadPeakLimit",
+      "name[zh_CN]": "远程下载忙时限速",
+      "description[zh_CN]": "传递优化远程下载忙时限速配置",
+      "description": "Delivery remote download peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-remote-upload-peak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryRemoteUploadPeakLimit",
+      "name[zh_CN]": "远程上传忙时限速",
+      "description[zh_CN]": "传递优化远程上传忙时限速配置",
+      "description": "Delivery remote upload peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-remote-download-offpeak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryRemoteDownloadOffPeakLimit",
+      "name[zh_CN]": "远程下载闲时限速",
+      "description[zh_CN]": "传递优化远程下载闲时限速配置",
+      "description": "Delivery remote download off-peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-remote-upload-offpeak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryRemoteUploadOffPeakLimit",
+      "name[zh_CN]": "远程上传闲时限速",
+      "description[zh_CN]": "传递优化远程上传闲时限速配置",
+      "description": "Delivery remote upload off-peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-local-download-global-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryLocalDownloadGlobalLimit",
+      "name[zh_CN]": "本地下载全局限速",
+      "description[zh_CN]": "传递优化本地下载全局限速配置",
+      "description": "Delivery local download global limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-local-upload-global-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryLocalUploadGlobalLimit",
+      "name[zh_CN]": "本地上传全局限速",
+      "description[zh_CN]": "传递优化本地上传全局限速配置",
+      "description": "Delivery local upload global limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-local-download-peak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryLocalDownloadPeakLimit",
+      "name[zh_CN]": "本地下载忙时限速",
+      "description[zh_CN]": "传递优化本地下载忙时限速配置",
+      "description": "Delivery local download peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-local-upload-peak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryLocalUploadPeakLimit",
+      "name[zh_CN]": "本地上传忙时限速",
+      "description[zh_CN]": "传递优化本地上传忙时限速配置",
+      "description": "Delivery local upload peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-local-download-offpeak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryLocalDownloadOffPeakLimit",
+      "name[zh_CN]": "本地下载闲时限速",
+      "description[zh_CN]": "传递优化本地下载闲时限速配置",
+      "description": "Delivery local download off-peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "delivery-local-upload-offpeak-limit": {
+      "value": "",
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DeliveryLocalUploadOffPeakLimit",
+      "name[zh_CN]": "本地上传闲时限速",
+      "description[zh_CN]": "传递优化本地上传闲时限速配置",
+      "description": "Delivery local upload off-peak limit",
+      "permissions": "readwrite",
+      "visibility": "private"
     }
   }
 }


### PR DESCRIPTION
* Fix the incorrect routing issue in ipfsconfig.
* Add both Acquire::delivery::Dl-Limit and Acquire::http::Dl-Limit to prevent local speed limit failure.
* Add default delivery speed limit configuration in dconfig.

Bug: https://pms.uniontech.com/bug-view-355955.html