### PR TITLE
fix(system): Fix Cancelable flag error for check_system job on failure

### DIFF
--- a/src/internal/system/dut/proxy.go
+++ b/src/internal/system/dut/proxy.go
@@ -78,6 +78,7 @@ func (p *DutSystem) CheckSystem(jobId string, checkType string, environ map[stri
 		}
 		return nil
 	})
+	fn.Cancelable = true
 	return fn.Start()
 }
 

--- a/src/internal/system/func.go
+++ b/src/internal/system/func.go
@@ -42,10 +42,12 @@ func (f *Function) atEnd(err error) {
 	}
 	progress := JobProgressInfo{
 		JobId:      f.JobId,
-		Cancelable: false,
+		Cancelable: f.Cancelable,
 	}
 	if err != nil {
 		// failed
+		// After failure, set progress.Cancelable to true
+		progress.Cancelable = true
 		progress.Progress = -1.0
 		progress.Status = FailedStatus
 		progress.Error = &JobError{


### PR DESCRIPTION
The bug occurred because Function.atEnd() incorrectly
reported Cancelable=false in failure scenarios, leaving a failed
check_system job in an abnormal terminal state, which further misled
systemOnChanging to remain true

Bug: https://pms.uniontech.com/bug-view-356225.html
Change-Id: I1ce2221f29d12291c08cf7f6d30e8af4fa027287
