### PR TITLE
fix: derive P2P update support from delivery repo prefix

### DIFF
--- a/src/internal/updateplatform/message_report.go
+++ b/src/internal/updateplatform/message_report.go
@@ -1383,12 +1383,20 @@ func (m *UpdatePlatformManager) updateLogMetaSync() error {
 }
 
 func (m *UpdatePlatformManager) genDepositoryFromPlatform() {
-	var repos []string
-	for _, repo := range m.repoInfos {
+	repos := genPlatformReposFromRepoInfos(m.repoInfos, m.config.PlatformRepoComponents, m.config.UpgradeDeliveryEnabled, m.config.IntranetUpdate)
+	err := os.WriteFile(system.PlatFormSourceFile, []byte(strings.Join(repos, "\n")), 0644)
+	if err != nil {
+		logger.Warning("update source list file err")
+	}
 
+}
+
+func genPlatformReposFromRepoInfos(repoInfos []repoInfo, platformRepoComponents string, upgradeDeliveryEnabled bool, intranetUpdate bool) []string {
+	var repos []string
+	for _, repo := range repoInfos {
 		// If the public network has Delivery Optimization enabled,
 		// then it is necessary to change http(s):// to delivery://.
-		if m.config.UpgradeDeliveryEnabled && !m.config.IntranetUpdate {
+		if upgradeDeliveryEnabled && !intranetUpdate {
 			httpPrefix := "http://"
 			httpsPrefix := "https://"
 			deliveryPrefix := "delivery://"
@@ -1403,8 +1411,8 @@ func (m *UpdatePlatformManager) genDepositoryFromPlatform() {
 			prefix := "deb"
 			// v25上应该是这个
 			suffix := "main community commercial"
-			if m.config.PlatformRepoComponents != "" {
-				suffix = m.config.PlatformRepoComponents
+			if platformRepoComponents != "" {
+				suffix = platformRepoComponents
 			}
 			codeName := repo.CodeName
 			// 如果有cdn，则使用cdn，效率更高
@@ -1415,11 +1423,7 @@ func (m *UpdatePlatformManager) genDepositoryFromPlatform() {
 			repos = append(repos, fmt.Sprintf("%s %s %s %s", prefix, uri, codeName, suffix))
 		}
 	}
-	err := os.WriteFile(system.PlatFormSourceFile, []byte(strings.Join(repos, "\n")), 0644)
-	if err != nil {
-		logger.Warning("update source list file err")
-	}
-
+	return repos
 }
 
 func getAptAuthConf(domain string) (user, password string) {

--- a/src/internal/updateplatform/message_report_test.go
+++ b/src/internal/updateplatform/message_report_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updateplatform
+
+import "testing"
+
+func TestGenPlatformReposFromRepoInfosConvertsToDeliveryWhenDeliveryEnabled(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Uri:      "https://professional-packages.chinauos.com/desktop-professional",
+			CodeName: "eagle",
+		},
+	}, "main", true, false)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}
+
+func TestGenPlatformReposFromRepoInfosKeepsServerRepoPrefixWhenDeliveryDisabled(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Uri:      "https://professional-packages.chinauos.com/desktop-professional",
+			CodeName: "eagle",
+		},
+	}, "main", false, false)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb https://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}
+
+func TestGenPlatformReposFromRepoInfosKeepsServerRepoPrefixForIntranet(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Uri:      "https://professional-packages.chinauos.com/desktop-professional",
+			CodeName: "eagle",
+		},
+	}, "main", true, true)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb https://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}
+
+func TestGenPlatformReposFromRepoInfosKeepsDeliverySource(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Source: "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main",
+		},
+	}, "", false, false)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -372,6 +372,9 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 						return nil
 					}
 				}
+				if m.updater != nil {
+					m.updater.refreshUpgradeDeliveryService()
+				}
 				if updateplatform.IsForceUpdate(m.updatePlatform.Tp) && m.updatePlatform.Tp != updateplatform.UpdateRegularly {
 					m.stopTimerUnit(lastoreRegularlyUpdate)
 				}

--- a/src/lastore-daemon/updater.go
+++ b/src/lastore-daemon/updater.go
@@ -24,6 +24,7 @@ import (
 	systemd1 "github.com/linuxdeepin/go-dbus-factory/system/org.freedesktop.systemd1"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/strv"
+	utils2 "github.com/linuxdeepin/go-lib/utils"
 )
 
 const (
@@ -126,6 +127,11 @@ func SetAPTSmartMirror(url string) error {
 }
 
 func (u *Updater) refreshUpgradeDeliveryService() {
+	// TODO: 公网更新传递是否一定开启PlatformUpdate
+	if !updateSourceSupportsP2P("/var/lib/lastore/platform.list") {
+		u.setPropP2PUpdateSupport(false)
+		return
+	}
 	// 检查upgrade服务是否被正常安装
 	_, err := u.service.NameHasOwner("org.deepin.upgradedelivery")
 	if err != nil {
@@ -167,6 +173,15 @@ func (u *Updater) refreshUpgradeDeliveryService() {
 		logger.Warning(err)
 		u.setPropP2PUpdateEnable(false)
 	}
+}
+
+func updateSourceSupportsP2P(sourcePath string) bool {
+	if !utils2.IsFileExist(sourcePath) {
+		return false
+	}
+
+	data, err := os.ReadFile(sourcePath)
+	return err == nil && strings.Contains(string(data), "delivery://")
 }
 
 type LocaleMirrorSource struct {

--- a/src/lastore-daemon/updater_test.go
+++ b/src/lastore-daemon/updater_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUpdateSourceSupportsP2PFromDeliveryPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "delivery repo",
+			content: "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    true,
+		},
+		{
+			name:    "delivery repo with apt options",
+			content: "deb [trusted=yes] delivery://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    true,
+		},
+		{
+			name:    "http repo",
+			content: "deb https://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    false,
+		},
+		{
+			name:    "commented delivery repo",
+			content: "# deb delivery://professional-packages.chinauos.com/desktop-professional eagle main\ndeb https://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourcePath := filepath.Join(t.TempDir(), "platform.list")
+			if err := os.WriteFile(sourcePath, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got := updateSourceSupportsP2P(sourcePath)
+			if got != tt.want {
+				t.Fatalf("updateSourceSupportsP2P() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateSourceSupportsP2PReturnsFalseForMissingSource(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "missing.list")
+
+	if updateSourceSupportsP2P(sourcePath) {
+		t.Fatal("updateSourceSupportsP2P() = true, want false")
+	}
+}


### PR DESCRIPTION
Set P2PUpdateSupport based on whether the update repository uses the delivery:// prefix returned by the update platform. Preserve the server repository protocol when generating platform sources, and refresh P2P support after updating platform repository data.

Bug: https://pms.uniontech.com/bug-view-356709.html