### PR TITLE
fix: derive P2P update support from delivery repo prefix

### DIFF
--- a/src/internal/updateplatform/message_report.go
+++ b/src/internal/updateplatform/message_report.go
@@ -918,7 +918,7 @@ func (m *UpdatePlatformManager) genUpdatePolicyByToken(updateInRelease bool) err
 	m.saveTaskId()
 	// 生成仓库和InRelease
 	if updateInRelease {
-		m.genDepositoryFromPlatform()
+		m.genRepositoryFromPlatform()
 		m.checkInReleaseFromPlatform()
 	}
 
@@ -1382,13 +1382,21 @@ func (m *UpdatePlatformManager) updateLogMetaSync() error {
 	return nil
 }
 
-func (m *UpdatePlatformManager) genDepositoryFromPlatform() {
-	var repos []string
-	for _, repo := range m.repoInfos {
+func (m *UpdatePlatformManager) genRepositoryFromPlatform() {
+	repos := genPlatformReposFromRepoInfos(m.repoInfos, m.config.PlatformRepoComponents, m.config.UpgradeDeliveryEnabled, m.config.IntranetUpdate)
+	err := os.WriteFile(system.PlatFormSourceFile, []byte(strings.Join(repos, "\n")), 0644)
+	if err != nil {
+		logger.Warning("update source list file err:", err)
+	}
 
+}
+
+func genPlatformReposFromRepoInfos(repoInfos []repoInfo, platformRepoComponents string, upgradeDeliveryEnabled bool, intranetUpdate bool) []string {
+	var repos []string
+	for _, repo := range repoInfos {
 		// If the public network has Delivery Optimization enabled,
 		// then it is necessary to change http(s):// to delivery://.
-		if m.config.UpgradeDeliveryEnabled && !m.config.IntranetUpdate {
+		if upgradeDeliveryEnabled && !intranetUpdate {
 			httpPrefix := "http://"
 			httpsPrefix := "https://"
 			deliveryPrefix := "delivery://"
@@ -1403,8 +1411,8 @@ func (m *UpdatePlatformManager) genDepositoryFromPlatform() {
 			prefix := "deb"
 			// v25上应该是这个
 			suffix := "main community commercial"
-			if m.config.PlatformRepoComponents != "" {
-				suffix = m.config.PlatformRepoComponents
+			if platformRepoComponents != "" {
+				suffix = platformRepoComponents
 			}
 			codeName := repo.CodeName
 			// 如果有cdn，则使用cdn，效率更高
@@ -1415,11 +1423,7 @@ func (m *UpdatePlatformManager) genDepositoryFromPlatform() {
 			repos = append(repos, fmt.Sprintf("%s %s %s %s", prefix, uri, codeName, suffix))
 		}
 	}
-	err := os.WriteFile(system.PlatFormSourceFile, []byte(strings.Join(repos, "\n")), 0644)
-	if err != nil {
-		logger.Warning("update source list file err")
-	}
-
+	return repos
 }
 
 func getAptAuthConf(domain string) (user, password string) {

--- a/src/internal/updateplatform/message_report_test.go
+++ b/src/internal/updateplatform/message_report_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updateplatform
+
+import "testing"
+
+func TestGenPlatformReposFromRepoInfosConvertsToDeliveryWhenDeliveryEnabled(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Uri:      "https://professional-packages.chinauos.com/desktop-professional",
+			CodeName: "eagle",
+		},
+	}, "main", true, false)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}
+
+func TestGenPlatformReposFromRepoInfosKeepsServerRepoPrefixWhenDeliveryDisabled(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Uri:      "https://professional-packages.chinauos.com/desktop-professional",
+			CodeName: "eagle",
+		},
+	}, "main", false, false)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb https://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}
+
+func TestGenPlatformReposFromRepoInfosKeepsServerRepoPrefixForIntranet(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Uri:      "https://professional-packages.chinauos.com/desktop-professional",
+			CodeName: "eagle",
+		},
+	}, "main", true, true)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb https://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}
+
+func TestGenPlatformReposFromRepoInfosKeepsDeliverySource(t *testing.T) {
+	repos := genPlatformReposFromRepoInfos([]repoInfo{
+		{
+			Source: "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main",
+		},
+	}, "", false, false)
+
+	if len(repos) != 1 {
+		t.Fatalf("len(repos) = %d, want 1", len(repos))
+	}
+	want := "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main"
+	if repos[0] != want {
+		t.Fatalf("repos[0] = %q, want %q", repos[0], want)
+	}
+}

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -372,6 +372,9 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 						return nil
 					}
 				}
+				if m.updater != nil {
+					m.updater.refreshUpgradeDeliveryService()
+				}
 				if updateplatform.IsForceUpdate(m.updatePlatform.Tp) && m.updatePlatform.Tp != updateplatform.UpdateRegularly {
 					m.stopTimerUnit(lastoreRegularlyUpdate)
 				}

--- a/src/lastore-daemon/updater.go
+++ b/src/lastore-daemon/updater.go
@@ -24,6 +24,7 @@ import (
 	systemd1 "github.com/linuxdeepin/go-dbus-factory/system/org.freedesktop.systemd1"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/strv"
+	utils2 "github.com/linuxdeepin/go-lib/utils"
 )
 
 const (
@@ -125,48 +126,101 @@ func SetAPTSmartMirror(url string) error {
 		0644) // #nosec G306
 }
 
+// refreshUpgradeDeliveryService 刷新升级传递服务的状态，同步配置与实际服务状态。
+// 该函数检查 P2P 更新源支持情况，并根据 UpgradeDeliveryEnabled 配置
+// 启动或关闭升级传递服务，确保 P2PUpdateEnable 属性与配置一致。
 func (u *Updater) refreshUpgradeDeliveryService() {
-	// 检查upgrade服务是否被正常安装
+	if u.config.IntranetUpdate {
+		// 是私网更新，先根据平台下发的仓库列表来判断
+		if !sourceFileHasDeliveryProtocol(system.PlatFormSourceFile) {
+			u.setPropP2PUpdateSupport(false)
+			return
+		}
+	}
+	// 检查 upgrade delivery 服务是否被正常安装
 	_, err := u.service.NameHasOwner("org.deepin.upgradedelivery")
 	if err != nil {
 		logger.Warning(err)
 		u.setPropP2PUpdateSupport(false)
 		return
 	}
-	object := u.service.Conn().Object("org.deepin.upgradedelivery", "/org/deepin/upgradedelivery")
+	upgradeDeliveryObject := u.service.Conn().Object("org.deepin.upgradedelivery", "/org/deepin/upgradedelivery")
 	var ret dbus.Variant
-	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
-	err = object.CallWithContext(ctx, "org.deepin.upgradedelivery.ServiceStatus", 0).Store(&ret)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
+	err = upgradeDeliveryObject.CallWithContext(ctx, "org.deepin.upgradedelivery.ServiceStatus", 0).Store(&ret)
 	if err != nil {
 		logger.Warning(err)
 		u.setPropP2PUpdateSupport(false)
 		return
 	}
 	u.setPropP2PUpdateSupport(true)
-	v := ret.Value()
-	u.setPropP2PUpdateEnable(u.config.UpgradeDeliveryEnabled)
-	// 情况一：当upgrade服务开启但P2PUpdateEnable关闭时，尝试关闭服务。若关闭失败则将P2PUpdateEnable恢复为true
-	if !u.P2PUpdateEnable && v == system.UpgradeDeliveryEnable {
-		err = object.Call("org.deepin.upgradedelivery.DisableService", 0).Err
-		if err != nil {
-			logger.Warning(err)
-			u.setPropP2PUpdateEnable(true)
+	serviceStatus := ret.Value()
+
+	// 应用 UpgradeDeliveryEnabled 配置
+	if u.config.UpgradeDeliveryEnabled {
+		// 配置启用：期望服务开启
+		if serviceStatus != system.UpgradeDeliveryEnable {
+			// 服务未开启，尝试启动
+			err = upgradeDeliveryObject.Call("org.deepin.upgradedelivery.StartService", 0).Err
+			if err != nil {
+				logger.Warning("failed to start upgrade delivery service", err)
+				u.setPropP2PUpdateEnable(false)
+			} else {
+				u.setPropP2PUpdateEnable(true)
+			}
 		} else {
-			err = object.Call("org.deepin.upgradedelivery.Clear", 0).Err
+			// 服务已开启
+			u.setPropP2PUpdateEnable(true)
 		}
-		return
+	} else {
+		// 配置禁用：期望服务关闭
+		if serviceStatus == system.UpgradeDeliveryEnable {
+			// 服务已开启，尝试关闭
+			err = upgradeDeliveryObject.Call("org.deepin.upgradedelivery.DisableService", 0).Err
+			if err != nil {
+				logger.Warning("failed to disable upgrade delivery service", err)
+				u.setPropP2PUpdateEnable(true)
+			} else {
+				err = upgradeDeliveryObject.Call("org.deepin.upgradedelivery.Clear", 0).Err
+				if err != nil {
+					logger.Warning("failed to clear upgrade delivery", err)
+				}
+				// 关闭了服务，但是清理失败，依然设置为 false
+				u.setPropP2PUpdateEnable(false)
+			}
+		} else {
+			// 服务已关闭
+			u.setPropP2PUpdateEnable(false)
+		}
 	}
-	// 情况二：当upgrade服务开启但P2PUpdateEnable为false时，将P2PUpdateEnable设置为true
-	if v == system.UpgradeDeliveryEnable {
-		u.setPropP2PUpdateEnable(true)
-		return
+}
+
+// sourceFileHasDeliveryProtocol checks whether the given source file contains
+// any non-comment line with the "delivery://" protocol prefix, indicating that
+// delivery-based (P2P) update repositories are available.
+func sourceFileHasDeliveryProtocol(sourcePath string) bool {
+	if !utils2.IsFileExist(sourcePath) {
+		return false
 	}
-	// 情况三：当upgrade服务未开启但P2PUpdateEnable为true时，尝试拉起服务。若拉起失败则将P2PUpdateEnable设置为false
-	err = object.Call("org.deepin.upgradedelivery.StartService", 0).Err
+
+	data, err := os.ReadFile(sourcePath)
 	if err != nil {
-		logger.Warning(err)
-		u.setPropP2PUpdateEnable(false)
+		return false
 	}
+
+	// Check line by line, return true only if a non-comment line contains "delivery://"
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "delivery://") {
+			return true
+		}
+	}
+	return false
 }
 
 type LocaleMirrorSource struct {

--- a/src/lastore-daemon/updater_test.go
+++ b/src/lastore-daemon/updater_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSourceFileHasDeliveryProtocol(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "delivery repo",
+			content: "deb delivery://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    true,
+		},
+		{
+			name:    "delivery repo with apt options",
+			content: "deb [trusted=yes] delivery://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    true,
+		},
+		{
+			name:    "http repo",
+			content: "deb https://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    false,
+		},
+		{
+			name:    "commented delivery repo",
+			content: "# deb delivery://professional-packages.chinauos.com/desktop-professional eagle main\ndeb https://professional-packages.chinauos.com/desktop-professional eagle main\n",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourcePath := filepath.Join(t.TempDir(), "platform.list")
+			if err := os.WriteFile(sourcePath, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got := sourceFileHasDeliveryProtocol(sourcePath)
+			if got != tt.want {
+				t.Fatalf("sourceFileHasDeliveryProtocol() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourceFileHasDeliveryProtocolReturnsFalseForMissingSource(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "missing.list")
+
+	if sourceFileHasDeliveryProtocol(sourcePath) {
+		t.Fatal("sourceFileHasDeliveryProtocol() = true, want false")
+	}
+}


### PR DESCRIPTION
Set P2PUpdateSupport based on whether the update repository uses the
delivery:// prefix returned by the update platform. Preserve the server
repository protocol when generating platform sources, and refresh P2P
support after updating platform repository data.

Bug: https://pms.uniontech.com/bug-view-356709.html
Change-Id: If6f425b8e750349acb1b7724e1316e6c7e440bac
