### PR TITLE
fix: use Contains instead of HasPrefix for delivery repo detection

### DIFF
--- a/src/internal/updateplatform/message_report.go
+++ b/src/internal/updateplatform/message_report.go
@@ -244,7 +244,7 @@ func (m *UpdatePlatformManager) GetCVEUpdateLogs(pkgs []string) map[string]CEVIn
 
 func (m *UpdatePlatformManager) HasDeliveryRepo() bool {
 	for _, repo := range m.repoInfos {
-		if strings.HasPrefix(repo.Source, "delivery://") {
+		if strings.Contains(repo.Source, "delivery://") {
 			return true
 		}
 	}


### PR DESCRIPTION
The delivery:// scheme may not always appear at the beginning of the source string, so using Contains is more robust for detecting delivery repositories.