### PR TITLE
fix: restore local download speed limit config on startup

### DIFF
--- a/src/lastore-daemon/updater.go
+++ b/src/lastore-daemon/updater.go
@@ -104,7 +104,7 @@ func NewUpdater(service *dbusutil.Service, m *Manager, config *Config) *Updater 
 		AutoInstallUpdates:          config.AutoInstallUpdates,
 		AutoInstallUpdateType:       config.AutoInstallUpdateType,
 		IdleDownloadConfig:          config.IdleDownloadConfig,
-		DownloadSpeedLimitConfig:    config.DownloadSpeedLimitConfig,
+		DownloadSpeedLimitConfig:    getStartupDownloadSpeedLimitConfig(config),
 		ClassifiedUpdatablePackages: config.ClassifiedUpdatablePackages,
 		systemdManager:              systemd1.NewManager(service.Conn()),
 	}
@@ -118,6 +118,23 @@ func NewUpdater(service *dbusutil.Service, m *Manager, config *Config) *Updater 
 	}
 	u.refreshUpgradeDeliveryService()
 	return u
+}
+
+func getStartupDownloadSpeedLimitConfig(config *Config) string {
+	startupConfig := strings.TrimSpace(config.DownloadSpeedLimitConfig)
+	if startupConfig != "" {
+		var persistedConfig downloadSpeedLimitConfig
+		if err := json.Unmarshal([]byte(startupConfig), &persistedConfig); err == nil && persistedConfig.DownloadSpeedLimitEnabled {
+			return startupConfig
+		}
+	}
+
+	localConfig := strings.TrimSpace(config.LocalDownloadSpeedLimitConfig)
+	if localConfig != "" {
+		return localConfig
+	}
+
+	return startupConfig
 }
 
 func SetAPTSmartMirror(url string) error {

--- a/src/lastore-daemon/updater_test.go
+++ b/src/lastore-daemon/updater_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
 )
 
 func TestSourceFileHasDeliveryProtocol(t *testing.T) {
@@ -58,5 +60,58 @@ func TestSourceFileHasDeliveryProtocolReturnsFalseForMissingSource(t *testing.T)
 
 	if sourceFileHasDeliveryProtocol(sourcePath) {
 		t.Fatal("sourceFileHasDeliveryProtocol() = true, want false")
+	}
+}
+
+func TestGetStartupDownloadSpeedLimitConfig(t *testing.T) {
+	localConfig := `{"DownloadSpeedLimitEnabled":true,"LimitSpeed":"2048","IsOnlineSpeedLimit":false}`
+	remoteConfig := `{"DownloadSpeedLimitEnabled":true,"LimitSpeed":"4096","IsOnlineSpeedLimit":true}`
+	defaultConfig := `{"DownloadSpeedLimitEnabled":false,"LimitSpeed":"1024","IsOnlineSpeedLimit":false}`
+
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want string
+	}{
+		{
+			name: "prefer local persisted config when startup config is not online speed limit",
+			cfg: config.Config{
+				DownloadSpeedLimitConfig:      defaultConfig,
+				LocalDownloadSpeedLimitConfig: localConfig,
+			},
+			want: localConfig,
+		},
+		{
+			name: "keep remote config when online speed limit is active",
+			cfg: config.Config{
+				DownloadSpeedLimitConfig:      remoteConfig,
+				LocalDownloadSpeedLimitConfig: localConfig,
+			},
+			want: remoteConfig,
+		},
+		{
+			name: "fallback to local config when startup config is invalid",
+			cfg: config.Config{
+				DownloadSpeedLimitConfig:      "{invalid json}",
+				LocalDownloadSpeedLimitConfig: localConfig,
+			},
+			want: localConfig,
+		},
+		{
+			name: "fallback to startup config when local config is empty",
+			cfg: config.Config{
+				DownloadSpeedLimitConfig: defaultConfig,
+			},
+			want: defaultConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStartupDownloadSpeedLimitConfig(&tt.cfg)
+			if got != tt.want {
+				t.Fatalf("getStartupDownloadSpeedLimitConfig() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Initialize DownloadSpeedLimitConfig from local-download-speed-limit when the persisted download-speed-limit is not an online rate-limit config.

This preserves user-configured local throttling across reboot while still keeping remote/platform rate limits when IsOnlineSpeedLimit is true.

Bug: https://pms.uniontech.com/bug-view-357171.html
Bug: https://pms.uniontech.com/bug-view-357713.html