### PR TITLE
fix: gate delivery repos on runtime support

### DIFF
--- a/src/internal/system/update_type.go
+++ b/src/internal/system/update_type.go
@@ -265,10 +265,9 @@ func UpdateSystemDefaultSourceDir(sourceList []string) error {
 	return nil
 }
 
-func UpdateP2pDefaultSourceDir(updateType UpdateType, upgradeDeliveryEnabled bool, platformRepos []string) error {
-	if !upgradeDeliveryEnabled {
-		return nil
-	}
+// UpdateP2pDefaultSourceDir 根据updateType更新对应的P2P下载默认源目录
+// 将源目录中的仓库协议替换为delivery协议，用于P2P下载更新
+func UpdateP2pDefaultSourceDir(updateType UpdateType, platformRepos []string) error {
 	logger.Infof("UpdateP2pDefaultSourceDir: updateType=%v, platformRepos=%v", updateType, platformRepos)
 	sourceDir := GetCategorySourceMap()[updateType]
 	p2pSource, err := ioutil.TempFile("/tmp", "p2pSource-*.list")

--- a/src/internal/updateplatform/message_report.go
+++ b/src/internal/updateplatform/message_report.go
@@ -41,6 +41,8 @@ import (
 
 var logger = log.NewLogger("lastore/messageReport")
 
+const defaultPlatformRepoComponents = "main community commercial"
+
 type ProcessEvent struct {
 	TaskID       int    `json:"taskID"`
 	EventType    int    `json:"eventType"`
@@ -259,11 +261,11 @@ func (m *UpdatePlatformManager) GetPlatformRepoSources() []string {
 			continue
 		}
 
-		suffix := "main community commercial"
+		components := defaultPlatformRepoComponents
 		if m.config != nil && m.config.PlatformRepoComponents != "" {
-			suffix = m.config.PlatformRepoComponents
+			components = m.config.PlatformRepoComponents
 		}
-		repos = append(repos, fmt.Sprintf("deb %s %s %s", repo.Uri, repo.CodeName, suffix))
+		repos = append(repos, fmt.Sprintf("deb %s %s %s", repo.Uri, repo.CodeName, components))
 	}
 	return repos
 }
@@ -907,7 +909,7 @@ func IsForceUpdate(tp UpdateTp) bool {
 }
 
 // GenUpdatePolicyByToken 检查更新时将token数据发送给更新平台，获取本次更新信息
-func (m *UpdatePlatformManager) genUpdatePolicyByToken(updateInRelease bool) error {
+func (m *UpdatePlatformManager) genUpdatePolicyByToken() error {
 	response, err := m.genVersionResponse()
 	if err != nil {
 		return fmt.Errorf("failed get version data %v", err)
@@ -945,29 +947,19 @@ func (m *UpdatePlatformManager) genUpdatePolicyByToken(updateInRelease bool) err
 	m.UpdateSourceList()
 	m.UpdateBaselineCache()
 	m.saveTaskId()
-	// 生成仓库和InRelease
-	if updateInRelease {
-		m.genRepositoryFromPlatform()
-		m.checkInReleaseFromPlatform()
-		if m.config.UpgradeDeliveryEnabled && !m.config.IntranetUpdate {
-			repos := m.GetPlatformRepoSources()
-			logger.Infof("UpdateP2pDefaultSourceDir: repos=%v", repos)
-			if err := system.UpdateP2pDefaultSourceDir(system.SystemUpdate, true, repos); err != nil {
-				logger.Warning(err)
-			}
-			if err := system.UpdateP2pDefaultSourceDir(system.SecurityUpdate, true, repos); err != nil {
-				logger.Warning(err)
-			}
-		}
-	}
-
 	return nil
 }
 
-func (m *UpdatePlatformManager) GenUpdatePolicyByToken(updateInRelease bool) error {
+// SyncRepoAndInRelease 从更新平台同步仓库源配置和InRelease到本地
+func (m *UpdatePlatformManager) SyncRepoAndInRelease(useP2PUpdate bool) {
+	m.genRepositoryFromPlatform(useP2PUpdate)
+	m.checkInReleaseFromPlatform()
+}
+
+func (m *UpdatePlatformManager) GenUpdatePolicyByToken() error {
 	var err error
 	if (m.config.PlatformDisabled & Cfg.DisabledVersion) == 0 {
-		err = m.genUpdatePolicyByToken(updateInRelease)
+		err = m.genUpdatePolicyByToken()
 	}
 	// 根据配置更新Tp
 	switch m.Tp {
@@ -1448,13 +1440,12 @@ func (m *UpdatePlatformManager) updateLogMetaSync() error {
 	return nil
 }
 
-func (m *UpdatePlatformManager) genRepositoryFromPlatform() {
-	repos := genPlatformReposFromRepoInfos(m.repoInfos, m.config.PlatformRepoComponents, m.config.UpgradeDeliveryEnabled, m.config.IntranetUpdate)
+func (m *UpdatePlatformManager) genRepositoryFromPlatform(useP2PUpdate bool) {
+	repos := genPlatformReposFromRepoInfos(m.repoInfos, m.config.PlatformRepoComponents, useP2PUpdate, m.config.IntranetUpdate)
 	err := os.WriteFile(system.PlatFormSourceFile, []byte(strings.Join(repos, "\n")), 0644)
 	if err != nil {
 		logger.Warning("update source list file err:", err)
 	}
-
 }
 
 func genPlatformReposFromRepoInfos(repoInfos []repoInfo, platformRepoComponents string, upgradeDeliveryEnabled bool, intranetUpdate bool) []string {
@@ -1476,9 +1467,9 @@ func genPlatformReposFromRepoInfos(repoInfos []repoInfo, platformRepoComponents 
 		} else {
 			prefix := "deb"
 			// v25上应该是这个
-			suffix := "main community commercial"
+			components := defaultPlatformRepoComponents
 			if platformRepoComponents != "" {
-				suffix = platformRepoComponents
+				components = platformRepoComponents
 			}
 			codeName := repo.CodeName
 			// 如果有cdn，则使用cdn，效率更高
@@ -1486,7 +1477,7 @@ func genPlatformReposFromRepoInfos(repoInfos []repoInfo, platformRepoComponents 
 			// if repo.Cdn != "" {
 			// 	uri = repo.Cdn
 			// }
-			repos = append(repos, fmt.Sprintf("%s %s %s %s", prefix, uri, codeName, suffix))
+			repos = append(repos, fmt.Sprintf("%s %s %s %s", prefix, uri, codeName, components))
 		}
 	}
 	return repos

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -155,13 +155,6 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 	}
 	prepareUpdateSource()
 	m.reloadOemConfig(true)
-	repos := m.updatePlatform.GetPlatformRepoSources()
-	if err := system.UpdateP2pDefaultSourceDir(system.SystemUpdate, m.updater.P2PUpdateEnable, repos); err != nil {
-		logger.Warning(err)
-	}
-	if err := system.UpdateP2pDefaultSourceDir(system.SecurityUpdate, m.updater.P2PUpdateEnable, repos); err != nil {
-		logger.Warning(err)
-	}
 	m.updatePlatform.Token = updateplatform.UpdateTokenConfigFile(m.config.IncludeDiskInfo, m.config.GetHardwareIdByHelper)
 	m.jobManager.dispatch() // 解决 bug 59351问题（防止CreatJob获取到状态为end但是未被删除的job）
 	var job *Job
@@ -364,7 +357,7 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 				_ = os.Setenv("https_proxy", environ["https_proxy"])
 				// 检查任务开始后,从更新平台获取仓库、更新注记等信息
 				// 从更新平台获取数据:系统更新和安全更新流程都包含
-				err = m.updatePlatform.GenUpdatePolicyByToken(true)
+				err = m.updatePlatform.GenUpdatePolicyByToken()
 				if err != nil {
 					if m.config.PlatformUpdate {
 						job.retry = 0
@@ -377,9 +370,27 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 						return nil
 					}
 				}
-				if m.updater != nil {
-					m.updater.refreshUpgradeDeliveryService()
+				if m.updater == nil {
+					return errors.New("Manager.updater is nil")
 				}
+
+				// 刷新P2P下载服务状态，判断是否启用P2P更新
+				m.updater.refreshUpgradeDeliveryService()
+				useP2PUpdate := m.updater.P2PUpdateSupport && m.updater.P2PUpdateEnable
+				if m.config.PlatformUpdate {
+					// 从更新平台同步仓库源配置和InRelease，若启用P2P则替换为delivery协议
+					m.updatePlatform.SyncRepoAndInRelease(useP2PUpdate)
+				} else if useP2PUpdate {
+					// 公网并且启用P2P时，将系统更新和安全更新的APT源的http(s)协议统一替换为delivery协议
+					repos := m.updatePlatform.GetPlatformRepoSources()
+					if err := system.UpdateP2pDefaultSourceDir(system.SystemUpdate, repos); err != nil {
+						logger.Warning(err)
+					}
+					if err := system.UpdateP2pDefaultSourceDir(system.SecurityUpdate, repos); err != nil {
+						logger.Warning(err)
+					}
+				}
+
 				if updateplatform.IsForceUpdate(m.updatePlatform.Tp) && m.updatePlatform.Tp != updateplatform.UpdateRegularly {
 					m.stopTimerUnit(lastoreRegularlyUpdate)
 				}
@@ -405,7 +416,7 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 						job.retry = 0
 						return &system.JobError{
 							ErrType:   system.ErrorPlatformUnreachable,
-							ErrDetail: "failed to get update info by update platform" + err.Error(),
+							ErrDetail: "failed to get update info by update platform: " + err.Error(),
 						}
 					} else {
 						return nil

--- a/src/lastore-daemon/updater.go
+++ b/src/lastore-daemon/updater.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	p2pService        = "uos-p2p.service"
-	defaultSpeedLimit = 1024
+	p2pService         = "uos-p2p.service"
+	defaultSpeedLimit  = 1024
+	deliveryMethodPath = "/usr/lib/apt/methods/delivery"
 )
 
 type ApplicationUpdateInfo struct {
@@ -153,6 +154,11 @@ func (u *Updater) refreshUpgradeDeliveryService() {
 			u.setPropP2PUpdateSupport(false)
 			return
 		}
+	}
+	if !utils2.IsFileExist(deliveryMethodPath) {
+		logger.Debugf("upgrade delivery apt method %s not found", deliveryMethodPath)
+		u.setPropP2PUpdateSupport(false)
+		return
 	}
 	// 检查 upgrade delivery 服务是否被正常安装
 	_, err := u.service.NameHasOwner("org.deepin.upgradedelivery")

--- a/src/lastore-tools/update_message.go
+++ b/src/lastore-tools/update_message.go
@@ -194,7 +194,7 @@ var updatePlatform *updateplatform.UpdatePlatformManager
 func UpdateMonitor() error {
 	config := NewConfig(path.Join(system.VarLibDir, "config.json"))
 	updatePlatform = updateplatform.NewUpdatePlatformManager(config, true)
-	err := updatePlatform.GenUpdatePolicyByToken(false)
+	err := updatePlatform.GenUpdatePolicyByToken()
 	if err != nil {
 		logger.Warning("gen update info failed:", err)
 		return err


### PR DESCRIPTION
Refresh delivery support before generating platform repos and switching
runtime sources to the delivery protocol. This keeps update checks on
http(s) sources when the delivery apt method or service is unavailable.

Bug: https://pms.uniontech.com/bug-view-358161.html
