### PR TITLE
fix: split upgrade delivery toggle permissions

### DIFF
--- a/src/lastore-daemon/common.go
+++ b/src/lastore-daemon/common.go
@@ -599,8 +599,12 @@ func checkSenderNsMntValid(pid uint32) bool {
 	return strings.TrimSpace(c) == _initProcNsMnt
 }
 
-const polkitActionChangeOwnData = "org.deepin.dde.accounts.user-administration"
-const polkitActionChangeUpgradeDelivery = "com.deepin.lastore.doUpgradeDelivery"
+const (
+	polkitActionChangeOwnData          = "org.deepin.dde.accounts.user-administration"
+	polkitActionChangeUpgradeDelivery  = "com.deepin.lastore.doUpgradeDelivery"
+	polkitActionEnableUpgradeDelivery  = "com.deepin.lastore.enableUpgradeDelivery"
+	polkitActionDisableUpgradeDelivery = "com.deepin.lastore.disableUpgradeDelivery"
+)
 
 func checkInvokePermission(service *dbusutil.Service, sender dbus.Sender) error {
 	uid, err := service.GetConnUID(string(sender))

--- a/src/lastore-daemon/updater_ifc.go
+++ b/src/lastore-daemon/updater_ifc.go
@@ -193,7 +193,13 @@ func (u *Updater) setDownloadSpeedLimit(limitConfigObj downloadSpeedLimitConfig)
 }
 
 func (u *Updater) SetP2PUpdateEnable(sender dbus.Sender, enable bool) *dbus.Error {
-	err := polkit.CheckAuth(polkitActionChangeUpgradeDelivery, string(sender), nil)
+	var action string
+	if enable {
+		action = polkitActionEnableUpgradeDelivery
+	} else {
+		action = polkitActionDisableUpgradeDelivery
+	}
+	err := polkit.CheckAuth(action, string(sender), nil)
 	if err != nil {
 		logger.Warning(err)
 		return dbusutil.ToError(err)

--- a/usr/share/polkit-1/actions/org.deepin.dde.Lastore1.policy
+++ b/usr/share/polkit-1/actions/org.deepin.dde.Lastore1.policy
@@ -45,4 +45,40 @@
             <message xml:lang="zh_HK">操作優化傳遞需認證</message>
             <annotate key="org.freedesktop.policykit.imply">org.deepin.upgradedelivery.change-status</annotate>
         </action>
+        <action id="com.deepin.lastore.enableUpgradeDelivery">
+            <description>Check Authentication</description>
+            <message>Turn on Delivery Optimization requires permission</message>
+            <defaults>
+                <allow_any>no</allow_any>
+                <allow_inactive>no</allow_inactive>
+                <allow_active>auth_admin_keep</allow_active>
+            </defaults>
+            <description xml:lang="en_US">Check Authentication</description>
+            <message xml:lang="en_US">Turn on Delivery Optimization requires permission</message>
+            <description xml:lang="zh_CN">Check Authentication</description>
+            <message xml:lang="zh_CN">开启优化传递需认证</message>
+            <description xml:lang="zh_TW">Check Authentication</description>
+            <message xml:lang="zh_TW">開啟最佳化傳遞需認證</message>
+            <description xml:lang="zh_HK">Check Authentication</description>
+            <message xml:lang="zh_HK">開啟優化傳遞需認證</message>
+            <annotate key="org.freedesktop.policykit.imply">org.deepin.upgradedelivery.change-status</annotate>
+        </action>
+        <action id="com.deepin.lastore.disableUpgradeDelivery">
+            <description>Check Authentication</description>
+            <message>Turn off Delivery Optimization requires permission</message>
+            <defaults>
+                <allow_any>no</allow_any>
+                <allow_inactive>no</allow_inactive>
+                <allow_active>auth_admin_keep</allow_active>
+            </defaults>
+            <description xml:lang="en_US">Check Authentication</description>
+            <message xml:lang="en_US">Turn off Delivery Optimization requires permission</message>
+            <description xml:lang="zh_CN">Check Authentication</description>
+            <message xml:lang="zh_CN">关闭优化传递需认证</message>
+            <description xml:lang="zh_TW">Check Authentication</description>
+            <message xml:lang="zh_TW">關閉最佳化傳遞需認證</message>
+            <description xml:lang="zh_HK">Check Authentication</description>
+            <message xml:lang="zh_HK">關閉優化傳遞需認證</message>
+            <annotate key="org.freedesktop.policykit.imply">org.deepin.upgradedelivery.change-status</annotate>
+        </action>
 </policyconfig>


### PR DESCRIPTION
Add dedicated polkit actions for enabling and disabling
upgrade delivery, and choose the action dynamically in
SetP2PUpdateEnable based on the requested state.

Bug: https://pms.uniontech.com/bug-view-358285.html
