### PR TITLE
feat: add mutual exclusion between online and local speed limit configs

### DIFF
--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -31,7 +31,7 @@ const (
 func (m *Manager) setEffectiveOnlineRateLimit(nowTime string) {
 	downloadSpeed := m.updater.downloadSpeedLimitConfigObj
 	m.applyOnlineRateLimit(&downloadSpeed, nowTime)
-	logger.Infof("set download limit %v --> %v by platform", m.updater.DownloadSpeedLimitConfig, downloadSpeed)
+	logger.Infof("set download limit %+v --> %+v by platform", m.updater.DownloadSpeedLimitConfig, downloadSpeed)
 	if err := m.updater.setDownloadSpeedLimit(downloadSpeed); err != nil {
 		logger.Warning(err)
 	}

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -489,11 +489,69 @@ func (m *Manager) refreshThrottlingFromPlatform() error {
 
 	m.applyOnlineRateLimit(&downloadSpeed, m.updatePlatform.OnlineRateLimit.ServerTime)
 
-	logger.Infof("set download limit %v --> %v by platform", m.updater.DownloadSpeedLimitConfig, downloadSpeed)
+	logger.Infof("set download limit %+v --> %+v by platform", m.updater.DownloadSpeedLimitConfig, downloadSpeed)
 	if err := m.updater.setDownloadSpeedLimit(downloadSpeed); err != nil {
 		logger.Warningf("Failed to set download speed limit %v", err)
 	}
 
+	if downloadSpeed.IsOnlineSpeedLimit {
+		// 如果启用了在线限速，禁用本地限速
+		if err := m.disableLocalSpeedLimitConfig(); err != nil {
+			logger.Warningf("Failed to disable local speed limit %v", err)
+		}
+	} else {
+		// 如果启用了本地限速，禁用在线限速
+		if err := m.disableOnlineSpeedLimitConfig(); err != nil {
+			logger.Warningf("Failed to disable online speed limit %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) disableOnlineSpeedLimitConfig() error {
+	var downloadSpeed downloadSpeedLimitConfig
+	if err := json.Unmarshal([]byte(m.config.DownloadSpeedLimitConfig), &downloadSpeed); err != nil {
+		downloadSpeed = downloadSpeedLimitConfig{
+			DownloadSpeedLimitEnabled: true,
+			LimitSpeed:                strconv.FormatInt(defaultSpeedLimit, 10),
+			IsOnlineSpeedLimit:        true,
+		}
+	}
+	if !downloadSpeed.DownloadSpeedLimitEnabled {
+		return nil
+	}
+	downloadSpeed.DownloadSpeedLimitEnabled = false
+	jsonStr, err := json.Marshal(downloadSpeed)
+	if err != nil {
+		return fmt.Errorf("failed to marshal download speed limit config: %w", err)
+	}
+	if err := m.config.SetDownloadSpeedLimitConfig(string(jsonStr)); err != nil {
+		return fmt.Errorf("failed to set download speed limit config: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) disableLocalSpeedLimitConfig() error {
+	var downloadSpeed downloadSpeedLimitConfig
+	if err := json.Unmarshal([]byte(m.config.LocalDownloadSpeedLimitConfig), &downloadSpeed); err != nil {
+		downloadSpeed = downloadSpeedLimitConfig{
+			DownloadSpeedLimitEnabled: true,
+			LimitSpeed:                strconv.FormatInt(defaultSpeedLimit, 10),
+			IsOnlineSpeedLimit:        false,
+		}
+	}
+	if !downloadSpeed.DownloadSpeedLimitEnabled {
+		return nil
+	}
+	downloadSpeed.DownloadSpeedLimitEnabled = false
+	jsonStr, err := json.Marshal(downloadSpeed)
+	if err != nil {
+		return fmt.Errorf("failed to marshal local download speed limit config: %w", err)
+	}
+	if err := m.config.SetLocalDownloadSpeedLimitConfig(string(jsonStr)); err != nil {
+		return fmt.Errorf("failed to set local download speed limit config: %w", err)
+	}
 	return nil
 }
 

--- a/src/lastore-daemon/updater_ifc.go
+++ b/src/lastore-daemon/updater_ifc.go
@@ -153,7 +153,7 @@ func (u *Updater) SetDownloadSpeedLimit(limitConfig string) *dbus.Error {
 func (u *Updater) setDownloadSpeedLimit(limitConfigObj downloadSpeedLimitConfig) error {
 	u.PropsMu.Lock()
 
-	logger.Infof("set download limit %v --> %v", u.downloadSpeedLimitConfigObj, limitConfigObj)
+	logger.Infof("set download limit %+v --> %+v", u.downloadSpeedLimitConfigObj, limitConfigObj)
 	u.downloadSpeedLimitConfigObj = limitConfigObj
 	config, err := json.Marshal(limitConfigObj)
 	if err != nil {
@@ -175,17 +175,18 @@ func (u *Updater) setDownloadSpeedLimit(limitConfigObj downloadSpeedLimitConfig)
 	u.setDownloadSpeedLimitTimer = time.AfterFunc(time.Second, func() {
 		u.PropsMu.Lock()
 		if !u.downloadSpeedLimitConfigObj.IsOnlineSpeedLimit {
+			logger.Info("update local speed limit config")
 			if err := u.config.SetLocalDownloadSpeedLimitConfig(configStr); err != nil {
 				logger.Warning(err)
 			}
 		} else {
+			logger.Info("update online speed limit config")
 			if err := u.config.SetDownloadSpeedLimitConfig(configStr); err != nil {
 				logger.Warning(err)
 			}
 		}
 		u.manager.ChangePrepareDistUpgradeJobOption()
 		u.PropsMu.Unlock()
-		logger.Info("update limit config")
 	})
 
 	u.PropsMu.Unlock()


### PR DESCRIPTION
When online speed limit is enabled, local speed limit will be disabled automatically, and vice versa. This prevents conflicts between the two limit modes. Also improve log formatting to show struct field names.