### PR TITLE
fix: update incrementalUpdate when related configs change

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -214,7 +214,7 @@ const (
 	dSettingsKeyUpdateProcessUpload                  = "update-process-upload"
 	dSettingsKeyEnableCoreList                       = "enable-core-list"
 	dSettingsKeyClientPackageName                    = "client-package-name"
-	dSettingsKeyUpgradeDeliveryEnabled               = "upgrade-delivery-enabled"
+	DSettingsKeyUpgradeDeliveryEnabled               = "upgrade-delivery-enabled"
 	dSettingsKeySystemCustomSource                   = "system-custom-source"
 	dSettingsKeySecurityCustomSource                 = "security-custom-source"
 	dSettingsKeySystemRepoType                       = "system-repo-type"
@@ -706,7 +706,7 @@ func getConfigFromDSettings() *Config {
 	}
 
 	updateUpgradeDeliveryEnabled := func() {
-		v, err = c.dsLastoreManager.Value(0, dSettingsKeyUpgradeDeliveryEnabled)
+		v, err = c.dsLastoreManager.Value(0, DSettingsKeyUpgradeDeliveryEnabled)
 		if err != nil {
 			logger.Warning(err)
 			c.UpgradeDeliveryEnabled = false
@@ -882,8 +882,21 @@ func getConfigFromDSettings() *Config {
 				}
 				c.dsettingsChangedCbMapMu.Unlock()
 			}
-		case dSettingsKeyUpgradeDeliveryEnabled:
-			updateUpgradeDeliveryEnabled()
+		case DSettingsKeyUpgradeDeliveryEnabled:
+			v, err = c.dsLastoreManager.Value(0, DSettingsKeyUpgradeDeliveryEnabled)
+			if err != nil {
+				logger.Warningf("failed to get value for %s: %v", DSettingsKeyUpgradeDeliveryEnabled, err)
+			} else {
+				oldValue := c.UpgradeDeliveryEnabled
+				newValue := v.Value().(bool)
+				c.UpgradeDeliveryEnabled = newValue
+				c.dsettingsChangedCbMapMu.Lock()
+				cb := c.dsettingsChangedCbMap[key]
+				if cb != nil {
+					go cb(oldValue, newValue)
+				}
+				c.dsettingsChangedCbMapMu.Unlock()
+			}
 		case DSettingsKeyLastoreDaemonStatus:
 			oldStatus := c.lastoreDaemonStatus
 			updateLastoreDaemonStatus()
@@ -1214,7 +1227,7 @@ func (c *Config) SetSystemRepoType(typ RepoType) error {
 
 func (c *Config) SetUpgradeDeliveryEnabled(enable bool) error {
 	c.UpgradeDeliveryEnabled = enable
-	return c.save(dSettingsKeyUpgradeDeliveryEnabled, enable)
+	return c.save(DSettingsKeyUpgradeDeliveryEnabled, enable)
 }
 
 func (c *Config) SetSecurityRepoType(typ RepoType) error {

--- a/src/internal/system/dut/proxy.go
+++ b/src/internal/system/dut/proxy.go
@@ -20,7 +20,7 @@ type DutSystem struct {
 }
 
 func NewSystem(nonUnknownList []string, otherList []string, incrementalUpdate bool) system.System {
-	logger.Debug("using dut for update...")
+	logger.Infof("using dut for update with nonUnknownList=%v otherList=%v incrementalUpdate=%v", nonUnknownList, otherList, incrementalUpdate)
 	aptImpl := apt.New(nonUnknownList, otherList, incrementalUpdate)
 	if !utils.IsFileExist(system.PlatFormSourceFile) {
 		file, err := os.Create(system.PlatFormSourceFile)

--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -233,10 +233,20 @@ func (m *Manager) initDSettingsChangedHandle() {
 			logger.Info("PlatformUrl changed to:", platformUrl)
 		}
 	})
+	// incrementalUpdate状态需要通过IntranetUpdate、UpgradeDeliveryEnabled以及IncrementalUpdate的组合来确定
+	// 因此当IntranetUpdate、UpgradeDeliveryEnabled以及IncrementalUpdate任意一个变化时，都需要更新incrementalUpdate状态
+	// 同时需要通过m.config.UseIncrementalUpdate()来获取最新的incrementalUpdate状态
 	m.config.ConnectConfigChanged(config.DSettingsKeyIncrementalUpdate, func(oldValue, newValue interface{}) {
-		incrementalUpdate := newValue.(bool)
+		rawIncrementalUpdate := newValue.(bool)
+		incrementalUpdate := m.config.UseIncrementalUpdate()
 		m.UpdateIncrementalUpdate(incrementalUpdate)
-		logger.Info("IncrementalUpdate changed to:", incrementalUpdate)
+		logger.Infof("IncrementalUpdate changed to %v with raw IncrementalUpdate=%v", incrementalUpdate, rawIncrementalUpdate)
+	})
+	m.config.ConnectConfigChanged(config.DSettingsKeyUpgradeDeliveryEnabled, func(oldValue, newValue interface{}) {
+		upgradeDeliveryEnabled := newValue.(bool)
+		incrementalUpdate := m.config.UseIncrementalUpdate()
+		m.UpdateIncrementalUpdate(incrementalUpdate)
+		logger.Infof("IncrementalUpdate changed to %v with UpgradeDeliveryEnabled=%v", incrementalUpdate, upgradeDeliveryEnabled)
 	})
 	m.config.ConnectConfigChanged(config.DSettingsKeyAutoDownloadUpdates, func(oldValue, newValue interface{}) {
 		autoDownloadUpdates := newValue.(bool)
@@ -258,6 +268,10 @@ func (m *Manager) initDSettingsChangedHandle() {
 			}
 			m.isAutoCheckTimerFirstRun = false
 		}
+
+		incrementalUpdate := m.config.UseIncrementalUpdate()
+		m.UpdateIncrementalUpdate(incrementalUpdate)
+		logger.Infof("IncrementalUpdate changed to %v with IntranetUpdate=%v", incrementalUpdate, intranetUpdate)
 	})
 }
 


### PR DESCRIPTION
incrementalUpdate state is determined by IntranetUpdate, UpgradeDeliveryEnabled and IncrementalUpdate combined. Update it when any of these configs change.

Bug: https://pms.uniontech.com/bug-view-358579.html