### PR TITLE
fix: remove PrivateIPC of lastore-daemon service to address potential hidden issue

### DIFF
--- a/lib/systemd/system/lastore-daemon.service
+++ b/lib/systemd/system/lastore-daemon.service
@@ -21,7 +21,6 @@ BusName=org.deepin.dde.Lastore1
 CacheDirectory=lastore
 ExecStart=/usr/libexec/lastore-daemon/lastore-daemon
 NoNewPrivileges=true
-PrivateIPC=true
 ProtectClock=true
 RuntimeDirectory=lastore
 RuntimeDirectoryMode=0750


### PR DESCRIPTION
This security hardening parameter caused the app store source to be cleared. To be safe, remove it here as well.