### PR TITLE
fix: separate stderr and stdout processing for delivery info

### DIFF
--- a/src/internal/system/apt/apt.go
+++ b/src/internal/system/apt/apt.go
@@ -137,7 +137,6 @@ func newAPTCommand(cmdSet system.CommandSet, jobId string, cmdType string, fn sy
 		Cancelable:                true,
 	}
 	cmd.Stdout = &r.Stdout
-	cmd.Stderr = &r.Stderr
 
 	cmdSet.AddCMD(r)
 	return r

--- a/src/internal/system/apt/proxy.go
+++ b/src/internal/system/apt/proxy.go
@@ -76,8 +76,8 @@ func parseDeliveryDownloadInfo(id, line string) (system.JobDeliveryDownloadInfo,
 			if len(kv) != 2 {
 				continue
 			}
-			key := kv[0]
-			value := kv[1]
+			key := strings.TrimSpace(kv[0])
+			value := strings.TrimSpace(kv[1])
 
 			if key != "IsFinish" && key != "Speed" && key != "Proto" {
 				continue
@@ -93,9 +93,10 @@ func parseDeliveryDownloadInfo(id, line string) (system.JobDeliveryDownloadInfo,
 				proto = value
 			}
 		}
+
+		jobDeliveryDownloadInfo.Proto = proto
 		if !isFinish {
 			jobDeliveryDownloadInfo.Speed = speed
-			jobDeliveryDownloadInfo.Proto = proto
 		} else {
 			jobDeliveryDownloadInfo.Speed = -1
 		}

--- a/src/internal/system/command.go
+++ b/src/internal/system/command.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -32,7 +33,9 @@ type Command struct {
 	cmdMu    sync.Mutex
 	ExitCode int
 
-	pipe *os.File
+	pipe    *os.File
+	stderrR *os.File
+	stderrW *os.File
 
 	Indicator                 Indicator
 	DeliveryIndicator         DeliveryIndicator
@@ -89,7 +92,12 @@ func (c *Command) Start() error {
 		_ = ww.Close()
 	}()
 
-	// Print command start information
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		_ = rr.Close()
+		return fmt.Errorf("aptCommand.Start stderr pipe: %v", err)
+	}
+
 	cmdStr := strings.Join(c.Cmd.Args, " ")
 	c.Indicator(JobProgressInfo{
 		OnlyLog:     true,
@@ -98,17 +106,24 @@ func (c *Command) Start() error {
 
 	c.Cmd.ExtraFiles = append(c.Cmd.ExtraFiles, ww)
 
+	c.stderrR = stderrR
+	c.stderrW = stderrW
+	c.Cmd.Stderr = io.MultiWriter(&c.Stderr, stderrW)
+
 	c.cmdMu.Lock()
 	err = c.Cmd.Start()
 	c.cmdMu.Unlock()
 	if err != nil {
 		_ = rr.Close()
+		_ = stderrR.Close()
+		_ = stderrW.Close()
 		return err
 	}
 
 	c.pipe = rr
 
 	go c.updateProgress()
+	go c.updateStderr()
 
 	go func() {
 		_ = c.Wait()
@@ -143,7 +158,16 @@ func (c *Command) atExit() {
 		logger.Warning("failed to close pipe:", err)
 	}
 
-	// Print command end information with status
+	err = c.stderrR.Close()
+	if err != nil {
+		logger.Warning("failed to close stderrR:", err)
+	}
+
+	err = c.stderrW.Close()
+	if err != nil {
+		logger.Warning("failed to close stderrW:", err)
+	}
+
 	var statusStr string
 	switch c.ExitCode {
 	case ExitSuccess:
@@ -195,7 +219,6 @@ func (c *Command) atExit() {
 				Error:      err,
 			})
 		} else {
-			// 解析错误后，确定错误为非阻塞性错误，那么认为是成功
 			c.Indicator(JobProgressInfo{
 				JobId:      c.JobId,
 				Status:     SucceedStatus,
@@ -277,27 +300,36 @@ func (c *Command) updateProgress() {
 			return
 		}
 
+		info, err := c.ParseProgressInfo(c.JobId, line)
+		if err != nil {
+			logger.Errorf("aptCommand.updateProgress %v -> %v\n", info, err)
+			c.Indicator(JobProgressInfo{
+				OnlyLog:     true,
+				OriginalLog: line,
+			})
+			continue
+		}
+		info.OriginalLog = line
+		c.Cancelable = info.Cancelable
+		c.Indicator(info)
+	}
+}
+
+func (c *Command) updateStderr() {
+	b := bufio.NewReader(c.stderrR)
+	for {
+		line, err := b.ReadString('\n')
+		if err != nil {
+			return
+		}
+
 		if strings.Contains(line, "102 Status") {
 			deliveryInfo, err := c.ParseDeliveryDownloadInfo(c.JobId, line)
 			if err != nil {
-				logger.Errorf("aptCommand.updateProgress %v -> %v\n", deliveryInfo, err)
+				logger.Errorf("aptCommand.updateStderr %v -> %v\n", deliveryInfo, err)
 				continue
 			}
 			c.DeliveryIndicator(deliveryInfo)
-			continue
-		} else {
-			info, err := c.ParseProgressInfo(c.JobId, line)
-			if err != nil {
-				logger.Errorf("aptCommand.updateProgress %v -> %v\n", info, err)
-				c.Indicator(JobProgressInfo{
-					OnlyLog:     true,
-					OriginalLog: line,
-				})
-				continue
-			}
-			info.OriginalLog = line
-			c.Cancelable = info.Cancelable
-			c.Indicator(info)
 		}
 	}
 }

--- a/src/lastore-daemon/job.go
+++ b/src/lastore-daemon/job.go
@@ -160,6 +160,7 @@ func (j *Job) updateDeliveryDownloadInfo(info system.JobDeliveryDownloadInfo) {
 
 	proto := normalizeDownloadProto(info.Proto)
 	if proto != j.Proto {
+		logger.Infof("emitPropChangedProto %s -> %s\n", j.Proto, proto)
 		j.Proto = proto
 		if j.service != nil {
 			_ = j.emitPropChangedProto(proto)


### PR DESCRIPTION
- Move 102 Status delivery download info parsing from stdout to stderr
- Add stderr pipe to Command struct for independent stderr handling
- Create updateStderr goroutine for stderr stream processing
- Add TrimSpace when parsing delivery info key-value pairs
- Ensure Proto field is always set regardless of isFinish status
- Properly close stderr pipe (both read and write ends) in atExit

Bug: https://pms.uniontech.com/bug-view-358359.html
Bug: https://pms.uniontech.com/bug-view-357559.html