### PR TITLE
fix: normalize p2p/delivery protocol to 'delivery'

### DIFF
--- a/src/lastore-daemon/job.go
+++ b/src/lastore-daemon/job.go
@@ -292,7 +292,7 @@ func normalizeDownloadProto(proto string) string {
 	case "http", "https":
 		return "http"
 	case "p2p", "delivery":
-		return "p2p"
+		return "delivery"
 	default:
 		return proto
 	}

--- a/src/lastore-daemon/job_test.go
+++ b/src/lastore-daemon/job_test.go
@@ -5,10 +5,11 @@
 package main
 
 import (
-	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
 )
 
 func TestJob(t *testing.T) {
@@ -57,8 +58,8 @@ func TestJobDeliveryDownloadInfoUpdatesSpeedAndNormalizedProto(t *testing.T) {
 	}{
 		{name: "http", proto: "http", wantProto: "http"},
 		{name: "https", proto: "https", wantProto: "http"},
-		{name: "p2p", proto: "p2p", wantProto: "p2p"},
-		{name: "delivery", proto: "delivery", wantProto: "p2p"},
+		{name: "p2p", proto: "p2p", wantProto: "delivery"},
+		{name: "delivery", proto: "delivery", wantProto: "delivery"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Change normalizeDownloadProto to return 'delivery' instead of 'p2p' for both p2p and delivery protocols.

Bug: https://pms.uniontech.com/bug-view-358359.html