### PR TITLE
feat: add config change callback for hardware-related settings

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -206,7 +206,7 @@ const (
 	DSettingsKeyPlatformUpdate                       = "platform-update"
 	DSettingsKeyPlatformUrl                          = "platform-url"
 	DSettingsKeyStartCheckRange                      = "start-check-range"
-	dSettingsKeyIncludeDiskInfo                      = "include-disk-info"
+	DSettingsKeyIncludeDiskInfo                      = "include-disk-info"
 	dSettingsKeyPostUpgradeOnCalendar                = "post-upgrade-on-calendar"
 	dSettingsKeyUpdateTime                           = "update-time"
 	dSettingsKeyPlatformDisabled                     = "platform-disabled"
@@ -222,7 +222,7 @@ const (
 	dSettingsKeyPlatformRepoComponents               = "platform-repo-components"
 	DSettingsKeyIncrementalUpdate                    = "incremental-update"
 	DSettingsKeyIntranetUpdate                       = "intranet-update"
-	dSettingsKeyGetHardwareIdByHelper                = "hardware-id-from-helper"
+	DSettingsKeyGetHardwareIdByHelper                = "hardware-id-from-helper"
 	DSettingsKeyDeliveryRemoteDownloadGlobalLimit    = "delivery-remote-download-global-limit"
 	DSettingsKeyDeliveryRemoteUploadGlobalLimit      = "delivery-remote-upload-global-limit"
 	DSettingsKeyDeliveryRemoteDownloadPeakLimit      = "delivery-remote-download-peak-limit"
@@ -656,7 +656,7 @@ func getConfigFromDSettings() *Config {
 		}
 	}
 
-	v, err = c.dsLastoreManager.Value(0, dSettingsKeyIncludeDiskInfo)
+	v, err = c.dsLastoreManager.Value(0, DSettingsKeyIncludeDiskInfo)
 	if err != nil {
 		logger.Warning(err)
 		c.IncludeDiskInfo = true
@@ -748,7 +748,7 @@ func getConfigFromDSettings() *Config {
 		c.SecurityRepoType = RepoType(v.Value().(string))
 	}
 
-	v, err = c.dsLastoreManager.Value(0, dSettingsKeyGetHardwareIdByHelper)
+	v, err = c.dsLastoreManager.Value(0, DSettingsKeyGetHardwareIdByHelper)
 	if err != nil {
 		logger.Warning(err)
 	} else {
@@ -838,19 +838,35 @@ func getConfigFromDSettings() *Config {
 				}
 				c.dsettingsChangedCbMapMu.Unlock()
 			}
-		case dSettingsKeyGetHardwareIdByHelper:
-			v, err = c.dsLastoreManager.Value(0, dSettingsKeyGetHardwareIdByHelper)
+		case DSettingsKeyGetHardwareIdByHelper:
+			v, err = c.dsLastoreManager.Value(0, DSettingsKeyGetHardwareIdByHelper)
 			if err != nil {
 				logger.Warning(err)
 			} else {
-				c.GetHardwareIdByHelper = v.Value().(bool)
+				oldValue := c.GetHardwareIdByHelper
+				newValue := v.Value().(bool)
+				c.GetHardwareIdByHelper = newValue
+				c.dsettingsChangedCbMapMu.Lock()
+				cb := c.dsettingsChangedCbMap[key]
+				if cb != nil {
+					go cb(oldValue, newValue)
+				}
+				c.dsettingsChangedCbMapMu.Unlock()
 			}
-		case dSettingsKeyIncludeDiskInfo:
-			v, err = c.dsLastoreManager.Value(0, dSettingsKeyIncludeDiskInfo)
+		case DSettingsKeyIncludeDiskInfo:
+			v, err = c.dsLastoreManager.Value(0, DSettingsKeyIncludeDiskInfo)
 			if err != nil {
 				logger.Warning(err)
 			} else {
-				c.IncludeDiskInfo = v.Value().(bool)
+				oldValue := c.IncludeDiskInfo
+				newValue := v.Value().(bool)
+				c.IncludeDiskInfo = newValue
+				c.dsettingsChangedCbMapMu.Lock()
+				cb := c.dsettingsChangedCbMap[key]
+				if cb != nil {
+					go cb(oldValue, newValue)
+				}
+				c.dsettingsChangedCbMapMu.Unlock()
 			}
 		case DSettingsKeyIncrementalUpdate:
 			v, err = c.dsLastoreManager.Value(0, DSettingsKeyIncrementalUpdate)

--- a/src/internal/updateplatform/systeminfo_utils.go
+++ b/src/internal/updateplatform/systeminfo_utils.go
@@ -6,6 +6,7 @@ package updateplatform
 
 import (
 	"bufio"
+	"bytes"
 	"crypto"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -524,7 +525,7 @@ var _tokenUpdateMu sync.Mutex
 
 // UpdateTokenConfigFile 更新 99lastore-token.conf 文件的内容
 func UpdateTokenConfigFile(includeDiskInfo bool, getHardwareIdByHelper bool) string {
-	logger.Debugf("UpdateTokenConfigFile includeDiskInfo: %v, getHardwareIdByHelper: %v", includeDiskInfo, getHardwareIdByHelper)
+	logger.Infof("UpdateTokenConfigFile includeDiskInfo: %v, getHardwareIdByHelper: %v", includeDiskInfo, getHardwareIdByHelper)
 	logger.Debug("start updateTokenConfigFile")
 	_tokenUpdateMu.Lock()
 	defer _tokenUpdateMu.Unlock()
@@ -552,8 +553,12 @@ func UpdateTokenConfigFile(includeDiskInfo bool, getHardwareIdByHelper bool) str
 	token := strings.Join(tokenSlice, ";")
 	token = strings.Replace(token, "\n", "", -1)
 	tokenContent := []byte("Acquire::SmartMirrors::Token \"" + token + "\";\n")
-	// TODO: may need to use chattr command to set tokenPath as immutable
-	err := os.WriteFile(tokenPath, tokenContent, 0644) // #nosec G306
+	existingContent, err := os.ReadFile(tokenPath)
+	if err == nil && bytes.Equal(existingContent, tokenContent) {
+		logger.Debug("token content unchanged, skip writing")
+		return token
+	}
+	err = os.WriteFile(tokenPath, tokenContent, 0644)
 	if err != nil {
 		logger.Warning(err)
 	}

--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -89,6 +89,7 @@ type Manager struct {
 	inhibitAutoQuitCount int32
 	autoQuitCountMu      sync.Mutex
 	lastoreUnitCacheMu   sync.Mutex
+	hardwareDataMu       sync.Mutex
 
 	loginManager  login1.Manager
 	sysDBusDaemon ofdbus.DBus
@@ -212,6 +213,26 @@ func (m *Manager) initDbusSignalListen() {
 	m.sysPower.InitSignalExt(m.signalLoop, true)
 }
 
+func (m *Manager) syncHardwareRelatedData() {
+	m.hardwareDataMu.Lock()
+	defer m.hardwareDataMu.Unlock()
+
+	logger.Info("syncing hardware related data...")
+
+	includeDiskInfo := m.config.IncludeDiskInfo
+	getHardwareIdByHelper := m.config.GetHardwareIdByHelper
+
+	token := updateplatform.UpdateTokenConfigFile(includeDiskInfo, getHardwareIdByHelper)
+	if m.updatePlatform != nil {
+		m.updatePlatform.Token = token
+	}
+
+	hardwareId := updateplatform.GetHardwareId(includeDiskInfo, getHardwareIdByHelper)
+	m.setPropHardwareId(hardwareId)
+
+	logger.Infof("sync completed")
+}
+
 func (m *Manager) initDSettingsChangedHandle() {
 	m.config.ConnectConfigChanged(config.DSettingsKeyLastoreDaemonStatus, func(oldValue, newValue interface{}) {
 		oldStatus := oldValue.(config.LastoreDaemonStatus)
@@ -272,6 +293,14 @@ func (m *Manager) initDSettingsChangedHandle() {
 		incrementalUpdate := m.config.UseIncrementalUpdate()
 		m.UpdateIncrementalUpdate(incrementalUpdate)
 		logger.Infof("IncrementalUpdate changed to %v with IntranetUpdate=%v", incrementalUpdate, intranetUpdate)
+	})
+	m.config.ConnectConfigChanged(config.DSettingsKeyIncludeDiskInfo, func(oldValue, newValue interface{}) {
+		logger.Infof("IncludeDiskInfo changed: %v -> %v", oldValue, newValue)
+		m.syncHardwareRelatedData()
+	})
+	m.config.ConnectConfigChanged(config.DSettingsKeyGetHardwareIdByHelper, func(oldValue, newValue interface{}) {
+		logger.Infof("GetHardwareIdByHelper changed: %v -> %v", oldValue, newValue)
+		m.syncHardwareRelatedData()
 	})
 }
 

--- a/src/lastore-daemon/manager_unit.go
+++ b/src/lastore-daemon/manager_unit.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
-	"github.com/linuxdeepin/lastore-daemon/src/internal/updateplatform"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -408,11 +407,7 @@ func (m *Manager) delHandleSystemEvent(sender dbus.Sender, eventType string) err
 		}()
 	case OsVersionChanged:
 		logger.Info("enter update token from OsVersionChanged")
-		if m.config.IntranetUpdate {
-			updateplatform.UpdateTokenConfigFile(m.config.IncludeDiskInfo, m.config.GetHardwareIdByHelper)
-		} else {
-			go updateplatform.UpdateTokenConfigFile(m.config.IncludeDiskInfo, m.config.GetHardwareIdByHelper)
-		}
+		m.syncHardwareRelatedData()
 	case InitIdleDownload:
 		m.updater.initIdleDownloadConfig()
 	case AutoDownload:


### PR DESCRIPTION
- Export DSettingsKeyIncludeDiskInfo and DSettingsKeyGetHardwareIdByHelper
- Add change callbacks for hardware-related config keys
- Add syncHardwareRelatedData() to unify hardware data synchronization
- Optimize token file writing to avoid redundant I/O
- Use synchronous calls to ensure state consistency

Bug: https://pms.uniontech.com/bug-view-359599.html