### PR TITLE
fix: ensure error logs are output for OnlyLog type and unknown errors

### DIFF
--- a/src/internal/system/apt/proxy.go
+++ b/src/internal/system/apt/proxy.go
@@ -264,7 +264,30 @@ func CheckPkgSystemError(lock bool, indicator system.Indicator) error {
 	if err == nil {
 		return nil
 	}
-	return parsePkgSystemError(outBuf.Bytes(), errBuf.Bytes())
+	if systemErr := parsePkgSystemError(outBuf.Bytes(), errBuf.Bytes()); systemErr != nil {
+		if jobErr, ok := systemErr.(*system.JobError); ok {
+			indicator(system.JobProgressInfo{
+				OnlyLog:     true,
+				OriginalLog: fmt.Sprintf("=== CheckPkg cmd failed: [%s] %s ===\n", jobErr.ErrType, jobErr.ErrDetail),
+			})
+		} else {
+			indicator(system.JobProgressInfo{
+				OnlyLog:     true,
+				OriginalLog: fmt.Sprintf("=== CheckPkg cmd failed: %s ===\n", errBuf.String()),
+			})
+		}
+		return systemErr
+	}
+
+	jobErr := &system.JobError{
+		ErrType:   system.ErrorUnknown,
+		ErrDetail: outBuf.String() + errBuf.String(),
+	}
+	indicator(system.JobProgressInfo{
+		OnlyLog:     true,
+		OriginalLog: fmt.Sprintf("=== CheckPkg cmd failed: [%s] %s ===\n", jobErr.ErrType, jobErr.ErrDetail),
+	})
+	return jobErr
 }
 
 func safeStart(c *system.Command) error {

--- a/src/lastore-daemon/job_manager.go
+++ b/src/lastore-daemon/job_manager.go
@@ -555,13 +555,14 @@ func (jm *JobManager) removeJob(jobId string, queueName string) error {
 }
 
 func (jm *JobManager) handleJobProgressInfo(info system.JobProgressInfo) {
+	// OnlyLog 类型基本上都不会设置JobId，将日志输出流程放到JobId判断之前来保证日志正常输出
+	if jm.jobDetailFn != nil && len(info.OriginalLog) > 0 {
+		jm.jobDetailFn(fmt.Sprintf("[%s] %s", time.Now().Format(time.DateTime), info.OriginalLog))
+	}
 	j := jm.findJobById(info.JobId)
 	if j == nil {
 		logger.Warningf("Can't find Job %q when update info %v\n", info.JobId, info)
 		return
-	}
-	if jm.jobDetailFn != nil && len(info.OriginalLog) > 0 {
-		jm.jobDetailFn(fmt.Sprintf("[%s] %s", time.Now().Format(time.DateTime), info.OriginalLog))
 	}
 	if info.OnlyLog {
 		return


### PR DESCRIPTION
- Add indicator logging in CheckPkgSystemError when parsePkgSystemError returns error
- Return ErrorUnknown JobError instead of silently dropping error when parsePkgSystemError returns nil
- Move log output before JobId check in handleJobProgressInfo to ensure OnlyLog messages are not skipped

Bug: https://pms.uniontech.com/bug-view-352601.html