### PR TITLE
fix(smartmirror): update CDN mirror source URLs with /deepin/ path prefix

### DIFF
--- a/etc/apt/apt.conf.d/99lastore.conf
+++ b/etc/apt/apt.conf.d/99lastore.conf
@@ -5,7 +5,7 @@ DPkg::Post-Invoke { "/var/lib/lastore/scripts/build_system_info || true "}
 Acquire::SmartMirrors::Enable true;
 Acquire::SmartMirrors::Debug false;
 Acquire::SmartMirrors::GuestURI "/usr/bin/lastore-smartmirror";
-Acquire::SmartMirrors::MainSource "https://community-packages.deepin.com/";
+Acquire::SmartMirrors::MainSource "https://cdn-community-packages.deepin.com/deepin/";
 Acquire::SmartMirrors::DomainList:: "deepin.com";
 Acquire::SmartMirrors::DomainList:: "deepin.org";
 Acquire::SmartMirrors::DomainList:: "uniontech.com";

--- a/etc/apt/apt.conf.d/99mirrors.conf
+++ b/etc/apt/apt.conf.d/99mirrors.conf
@@ -1,3 +1,3 @@
-#Don't wirte anything except MirrorSource, otherwise the config may lost
+#Don't write anything except MirrorSource, otherwise the config may lost
 
-Acquire::SmartMirrors::MirrorSource "https://cdn-community-packages.deepin.com/";
+Acquire::SmartMirrors::MirrorSource "https://cdn-community-packages.deepin.com/deepin/";

--- a/src/lastore-smartmirror-daemon/smartmirror.go
+++ b/src/lastore-smartmirror-daemon/smartmirror.go
@@ -114,6 +114,13 @@ func (s *SmartMirror) SetEnable(enable bool) *dbus.Error {
 
 // Query the best source
 func (s *SmartMirror) Query(original, officialMirror, mirrorHost string) (url string, busErr *dbus.Error) {
+	// Ensure that both officialMirror and mirrorHost end with "/" to maintain URL concatenation consistency
+	if !strings.HasSuffix(officialMirror, "/") {
+		officialMirror += "/"
+	}
+	if !strings.HasSuffix(mirrorHost, "/") {
+		mirrorHost += "/"
+	}
 	logger.Debug("Query", original, officialMirror, mirrorHost)
 	s.service.DelayAutoQuit()
 	if !s.Enable {


### PR DESCRIPTION
- Add /deepin/ path to MainSource and MirrorSource CDN URLs
- Normalize trailing slashes in Query() to ensure correct URL concatenation
- Fix typo in 99mirrors.conf comment
Bug: https://pms.uniontech.com/bug-view-360997.html
