### PR TITLE
feat(polkit): add custom action for user administration

### DIFF
--- a/src/lastore-daemon/common.go
+++ b/src/lastore-daemon/common.go
@@ -600,7 +600,7 @@ func checkSenderNsMntValid(pid uint32) bool {
 }
 
 const (
-	polkitActionChangeOwnData          = "org.deepin.dde.accounts.user-administration"
+	polkitActionChangeOwnData          = "com.deepin.lastore.user-administration"
 	polkitActionChangeUpgradeDelivery  = "com.deepin.lastore.doUpgradeDelivery"
 	polkitActionEnableUpgradeDelivery  = "com.deepin.lastore.enableUpgradeDelivery"
 	polkitActionDisableUpgradeDelivery = "com.deepin.lastore.disableUpgradeDelivery"

--- a/usr/share/polkit-1/actions/org.deepin.dde.Lastore1.policy
+++ b/usr/share/polkit-1/actions/org.deepin.dde.Lastore1.policy
@@ -81,4 +81,21 @@
             <message xml:lang="zh_HK">關閉優化傳遞需認證</message>
             <annotate key="org.freedesktop.policykit.imply">org.deepin.upgradedelivery.change-status</annotate>
         </action>
+        <action id="com.deepin.lastore.user-administration">
+            <description>Check Authentication</description>
+            <message>Authentication is required to perform this action</message>
+            <defaults>
+                <allow_any>no</allow_any>
+                <allow_inactive>no</allow_inactive>
+                <allow_active>auth_admin</allow_active>
+            </defaults>
+            <description xml:lang="en_US">Check Authentication</description>
+            <message xml:lang="en_US">Authentication is required to perform this action</message>
+            <description xml:lang="zh_CN">需要密码认证</description>
+            <message xml:lang="zh_CN">当前操作需要密码认证</message>
+            <description xml:lang="zh_TW">需要密碼認證</description>
+            <message xml:lang="zh_TW">當前操作需要密碼認證</message>
+            <description xml:lang="zh_HK">需要密碼認證</description>
+            <message xml:lang="zh_HK">當前操作需要密碼認證</message>
+        </action>
 </policyconfig>


### PR DESCRIPTION
Add new polkit action com.deepin.lastore.user-administration with multi-language support for zh_CN, zh_TW, zh_HK and en_US.

新增自定义 polkit action，支持简体中文、英文、繁体中文。

Log: 新增自定义 polkit action
PMS: BUG-354247
Influence: 用户管理操作的认证提示支持多语言显示。