### PR TITLE
fix(job_manager): skip zero-size packages and handle empty job list

### DIFF
--- a/src/lastore-daemon/job_manager.go
+++ b/src/lastore-daemon/job_manager.go
@@ -125,6 +125,9 @@ func (jm *JobManager) CreateJob(jobName, jobType string, packages []string, envi
 		}
 		for _, typ := range system.AllInstallUpdateType() {
 			if typ&mode != 0 {
+				if sizeMap[typ.JobType()] == 0 {
+					continue
+				}
 				// 使用dist-upgrade解决"有正在安装job时，依赖环境发生改变而导致检查依赖错误的问题"
 				partJob := NewJob(jm.service, genJobId(jobType), jobName, packageMap[typ.JobType()], system.PrepareDistUpgradeJobType, DownloadQueue, environ)
 				if utils.IsDir(system.GetCategorySourceMap()[typ]) {
@@ -150,6 +153,9 @@ func (jm *JobManager) CreateJob(jobName, jobType string, packages []string, envi
 				partJob._InitProgressRange(holderSize/allDownloadSize, (holderSize+sizeMap[typ.JobType()])/allDownloadSize)
 				holderSize += sizeMap[typ.JobType()]
 			}
+		}
+		if len(jobList) == 0 {
+			return false, nil, fmt.Errorf("no downloadable packages found")
 		}
 		job = jobList[0]
 

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -487,7 +487,7 @@ func (m *Manager) QueryAllSizeWithSource(mode system.UpdateType) (int64, *dbus.E
 	if err != nil || allSize == system.SizeUnknown {
 		logger.Warningf("failed to get %v source size:%v", strings.Join(sourcePathList, " and "), err)
 	} else {
-		logger.Infof("%v size is:%v M", strings.Join(sourcePathList, " and "), int64(allSize/(1000*1000)))
+		logger.Infof("%v size is:%s", strings.Join(sourcePathList, " and "), formatSize(float64(allSize)))
 	}
 
 	return int64(allSize), dbusutil.ToError(err)


### PR DESCRIPTION
Skip packages with size 0 during download job creation. Return error when no downloadable packages found.
Use formatSize for better size display in logs.

跳过大小为0的包，无可下载包时返回错误。
日志中使用 formatSize 函数显示大小。

Log: 跳过大小为0的包，优化日志显示
PMS: BUG-354719
Influence: 创建下载任务时跳过大小为0的包，避免无效任务；日志显示更友好的大小格式。