### PR TITLE
feat(security): migrate cache files and add secure file writing

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/linuxdeepin/go-lib/log"
 
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
+	"github.com/linuxdeepin/lastore-daemon/src/internal/utils"
 
 	"github.com/godbus/dbus/v5"
 	ConfigManager "github.com/linuxdeepin/go-dbus-factory/org.desktopspec.ConfigManager"
@@ -238,6 +240,13 @@ const (
 )
 
 const configTimeLayout = "2006-01-02T15:04:05.999999999-07:00"
+
+var (
+	legacyOnlineCachePath     = "/tmp/platform_cache.json"
+	legacyClassifiedCachePath = "/tmp/classified_cache.json"
+	onlineCachePath           = "/var/lib/lastore/platform_cache.json"
+	classifiedCachePath       = "/var/lib/lastore/classified_cache.json"
+)
 
 func getConfigFromDSettings() *Config {
 	c := &Config{}
@@ -766,7 +775,7 @@ func getConfigFromDSettings() *Config {
 	}
 
 	// classifiedCachePath和onlineCachePath两项数据没有存储在dconfig中，是因为数据量太大，dconfig不支持存储这么长的数据
-	content, err := os.ReadFile(classifiedCachePath)
+	content, err := readCacheWithLegacyFallback(classifiedCachePath, legacyClassifiedCachePath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			logger.Warning(err)
@@ -779,7 +788,7 @@ func getConfigFromDSettings() *Config {
 		}
 	}
 
-	content, err = os.ReadFile(onlineCachePath)
+	content, err = readCacheWithLegacyFallback(onlineCachePath, legacyOnlineCachePath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			logger.Warning(err)
@@ -1263,11 +1272,6 @@ func (c *Config) SetStartCheckRange(checkRange []int) error {
 	return c.save(DSettingsKeyStartCheckRange, variants)
 }
 
-const (
-	onlineCachePath     = "/tmp/platform_cache.json"
-	classifiedCachePath = "/tmp/classified_cache.json"
-)
-
 func (c *Config) SetClassifiedUpdatablePackages(pkgMap map[string][]string) error {
 	content, err := json.Marshal(pkgMap)
 	if err != nil {
@@ -1275,12 +1279,23 @@ func (c *Config) SetClassifiedUpdatablePackages(pkgMap map[string][]string) erro
 		return err
 	}
 	c.ClassifiedUpdatablePackages = pkgMap
-	return os.WriteFile(classifiedCachePath, content, 0644)
+	return utils.WriteFileSecurely(classifiedCachePath, content, 0644)
 }
 
 func (c *Config) SetOnlineCache(cache string) error {
 	c.OnlineCache = cache
-	return os.WriteFile(onlineCachePath, []byte(cache), 0644)
+	return utils.WriteFileSecurely(onlineCachePath, []byte(cache), 0644)
+}
+
+func readCacheWithLegacyFallback(path, legacyPath string) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		return content, err
+	}
+	if legacyPath == "" {
+		return nil, err
+	}
+	return os.ReadFile(legacyPath)
 }
 
 func (c *Config) GetPlatformStatusDisable(status DisabledStatus) bool {

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -78,3 +78,94 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, configAfter.AppstoreRegion, configBefore.AppstoreRegion+"Test")
 	assert.Equal(t, configAfter.UpdateMode, configBefore.UpdateMode+1)
 }
+
+func withTestCachePaths(t *testing.T) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	prevOnline := onlineCachePath
+	prevClassified := classifiedCachePath
+	prevLegacyOnline := legacyOnlineCachePath
+	prevLegacyClassified := legacyClassifiedCachePath
+	onlineCachePath = tempDir + "/platform_cache.json"
+	classifiedCachePath = tempDir + "/classified_cache.json"
+	legacyOnlineCachePath = tempDir + "/legacy_platform_cache.json"
+	legacyClassifiedCachePath = tempDir + "/legacy_classified_cache.json"
+
+	t.Cleanup(func() {
+		onlineCachePath = prevOnline
+		classifiedCachePath = prevClassified
+		legacyOnlineCachePath = prevLegacyOnline
+		legacyClassifiedCachePath = prevLegacyClassified
+	})
+}
+
+func TestSetOnlineCacheRejectsSymlinkTarget(t *testing.T) {
+	withTestCachePaths(t)
+
+	targetFile, err := os.CreateTemp("", "lastore-online-cache-target-*")
+	require.NoError(t, err)
+	targetPath := targetFile.Name()
+	require.NoError(t, targetFile.Close())
+	t.Cleanup(func() {
+		_ = os.Remove(targetPath)
+	})
+
+	originalContent := []byte("original")
+	require.NoError(t, os.WriteFile(targetPath, originalContent, 0600))
+	require.NoError(t, os.Symlink(targetPath, onlineCachePath))
+
+	cfg := &Config{}
+	err = cfg.SetOnlineCache(`{"safe":true}`)
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, onlineCachePath+".tmp-*")
+	content, readErr := os.ReadFile(onlineCachePath)
+	require.NoError(t, readErr)
+	assert.Equal(t, `{"safe":true}`, string(content))
+
+	content, readErr = os.ReadFile(targetPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, originalContent, content)
+}
+
+func TestSetClassifiedUpdatablePackagesRejectsSymlinkTarget(t *testing.T) {
+	withTestCachePaths(t)
+
+	targetFile, err := os.CreateTemp("", "lastore-classified-cache-target-*")
+	require.NoError(t, err)
+	targetPath := targetFile.Name()
+	require.NoError(t, targetFile.Close())
+	t.Cleanup(func() {
+		_ = os.Remove(targetPath)
+	})
+
+	originalContent := []byte("original")
+	require.NoError(t, os.WriteFile(targetPath, originalContent, 0600))
+	require.NoError(t, os.Symlink(targetPath, classifiedCachePath))
+
+	cfg := &Config{}
+	err = cfg.SetClassifiedUpdatablePackages(map[string][]string{
+		"system": {"pkg1"},
+	})
+	require.NoError(t, err)
+
+	content, readErr := os.ReadFile(classifiedCachePath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(content), "system")
+
+	content, readErr = os.ReadFile(targetPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, originalContent, content)
+}
+
+func TestReadCacheWithLegacyFallback(t *testing.T) {
+	withTestCachePaths(t)
+
+	legacyContent := []byte(`{"cached":true}`)
+	require.NoError(t, os.WriteFile(legacyOnlineCachePath, legacyContent, 0600))
+
+	content, err := readCacheWithLegacyFallback(onlineCachePath, legacyOnlineCachePath)
+	require.NoError(t, err)
+	assert.Equal(t, legacyContent, content)
+}

--- a/src/internal/utils/utils.go
+++ b/src/internal/utils/utils.go
@@ -18,9 +18,12 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 	"unsafe"
+
+	"github.com/linuxdeepin/go-lib/keyfile"
 )
 
 func RunCommand(prog string, args ...string) (string, error) {
@@ -178,4 +181,52 @@ func doUnsetEnvC(envName string) {
 	cname := C.CString(envName)
 	defer C.free(unsafe.Pointer(cname))
 	C.unsetenv(cname)
+}
+
+func WriteFileSecurely(path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+
+	tmpPath := tmpFile.Name()
+	cleanup := true
+	defer func() {
+		_ = tmpFile.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = tmpFile.Write(content); err != nil {
+		return err
+	}
+	if err = tmpFile.Chmod(perm); err != nil {
+		return err
+	}
+	if err = tmpFile.Sync(); err != nil {
+		return err
+	}
+	if err = tmpFile.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+
+	cleanup = false
+	return nil
+}
+
+func SaveKeyFileSecurely(path string, kf *keyfile.KeyFile, perm os.FileMode) error {
+	var buf bytes.Buffer
+	if err := kf.SaveToWriter(&buf); err != nil {
+		return err
+	}
+	return WriteFileSecurely(path, buf.Bytes(), perm)
 }

--- a/src/lastore-daemon/agent.go
+++ b/src/lastore-daemon/agent.go
@@ -21,7 +21,7 @@ import (
 	"github.com/linuxdeepin/lastore-daemon/src/internal/utils"
 )
 
-const userAgentRecordPath = "/tmp/lastoreAgentCache"
+var userAgentRecordPath = "/run/lastore/lastoreAgentCache"
 
 type userAgentMap struct {
 	mu         sync.Mutex
@@ -324,7 +324,12 @@ func (m *userAgentMap) getAgentsInfo() *userAgentInfoMap {
 
 // 将agent数据序列化成JSON格式写入recordFilePath中
 func (m *userAgentMap) saveRecordContent(recordFilePath string) {
-	err := utils.WriteData(recordFilePath, m.getAgentsInfo())
+	content, err := json.Marshal(m.getAgentsInfo())
+	if err != nil {
+		logger.Warning(err)
+		return
+	}
+	err = utils.WriteFileSecurely(recordFilePath, content, 0600)
 	if err != nil {
 		logger.Warning(err)
 	}

--- a/src/lastore-daemon/manager_test.go
+++ b/src/lastore-daemon/manager_test.go
@@ -6,11 +6,13 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
+	"github.com/linuxdeepin/lastore-daemon/src/internal/utils"
 
 	"github.com/linuxdeepin/go-lib/keyfile"
 	"github.com/stretchr/testify/assert"
@@ -62,9 +64,16 @@ func Test_canAutoQuit(t *testing.T) {
 }
 
 func Test_saveUpdateSourceOnce(t *testing.T) {
+	tempDir := t.TempDir()
+	prevUnitCache := lastoreUnitCache
+	lastoreUnitCache = filepath.Join(tempDir, "lastoreUnitCache")
+	t.Cleanup(func() {
+		lastoreUnitCache = prevUnitCache
+	})
+
 	kf := keyfile.NewKeyFile()
 	kf.SetBool("RecordData", "UpdateSourceOnce", false)
-	err := kf.SaveToFile(lastoreUnitCache)
+	err := utils.SaveKeyFileSecurely(lastoreUnitCache, kf, 0644)
 	if err != nil {
 		logger.Warning(err)
 		return
@@ -77,4 +86,17 @@ func Test_saveUpdateSourceOnce(t *testing.T) {
 	assert.FileExists(t, lastoreUnitCache)
 	m.loadUpdateSourceOnce()
 	assert.Equal(t, true, m.updateSourceOnce)
+}
+
+func Test_saveUserAgentRecordContent(t *testing.T) {
+	tempDir := t.TempDir()
+	prevRecordPath := userAgentRecordPath
+	userAgentRecordPath = filepath.Join(tempDir, "lastoreAgentCache")
+	t.Cleanup(func() {
+		userAgentRecordPath = prevRecordPath
+	})
+
+	agents := newUserAgentMap()
+	agents.saveRecordContent(userAgentRecordPath)
+	assert.FileExists(t, userAgentRecordPath)
 }

--- a/src/lastore-daemon/manager_unit.go
+++ b/src/lastore-daemon/manager_unit.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
+	"github.com/linuxdeepin/lastore-daemon/src/internal/utils"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -26,11 +27,11 @@ import (
 )
 
 const (
-	lastoreUnitCache = "/tmp/lastoreUnitCache"
 	run              = "systemd-run"
-	lastoreDBusCmd   = "dbus-send --system --print-reply --dest=org.deepin.dde.Lastore1 /org/deepin/dde/Lastore1 org.deepin.dde.Lastore1.Manager.HandleSystemEvent"
 	deepinDaemonUser = "deepin-daemon"
 )
+
+var lastoreUnitCache = "/run/lastore/lastoreUnitCache"
 
 // isFirstBoot startOfflineTask执行前执行有效
 func isFirstBoot() bool {
@@ -176,7 +177,7 @@ func (m *Manager) startOfflineTask() {
 		kf.SetString("UnitName", string(name), fmt.Sprintf("%s.unit", name))
 	}
 
-	err := kf.SaveToFile(lastoreUnitCache)
+	err := utils.SaveKeyFileSecurely(lastoreUnitCache, kf, 0644)
 	if err != nil {
 		logger.Warning(err)
 	}
@@ -194,7 +195,7 @@ func (m *Manager) saveUpdateSourceOnce() {
 		return
 	}
 	kf.SetBool("RecordData", "UpdateSourceOnce", true)
-	err = kf.SaveToFile(lastoreUnitCache)
+	err = utils.SaveKeyFileSecurely(lastoreUnitCache, kf, 0644)
 	if err != nil {
 		logger.Warning(err)
 	}


### PR DESCRIPTION
Move cache file paths from /tmp to /var/lib/lastore and /run/lastore for better security. Add symlink attack prevention in file operations.

将缓存文件路径从/tmp迁移到/var/lib/lastore和/run/lastore，
并添加安全文件写入函数防止符号链接攻击。

Log: 迁移缓存文件路径并添加安全文件写入功能
PMS: TASK-389535
Influence: 提升系统安全性，防止缓存文件被恶意符号链接篡改。