### PR TITLE
refactor(system): move locale env collection to system package for child process reuse

### DIFF
--- a/src/internal/system/apt/proxy.go
+++ b/src/internal/system/apt/proxy.go
@@ -756,6 +756,14 @@ func (p *APTSystem) OsBackup(jobId string) error {
 	environ := map[string]string{
 		"IMMUTABLE_DISABLE_REMOUNT": "false",
 	}
+	for _, env := range system.OriginalLocaleEnvs {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		environ[parts[0]] = parts[1]
+	}
+
 	c.SetEnv(environ)
 	c.Indicator(system.JobProgressInfo{
 		JobId:         jobId,

--- a/src/internal/system/common.go
+++ b/src/internal/system/common.go
@@ -19,6 +19,7 @@ import (
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/keyfile"
 	"github.com/linuxdeepin/go-lib/log"
+	"github.com/linuxdeepin/lastore-daemon/src/internal/utils"
 )
 
 const (
@@ -39,11 +40,25 @@ type MirrorSource struct {
 
 var RepoInfos []RepositoryInfo
 var logger = log.NewLogger("lastore/system")
+var OriginalLocaleEnvs []string
 
 type RepositoryInfo struct {
 	Name   string `json:"name"`
 	Url    string `json:"url"`
 	Mirror string `json:"mirror"`
+}
+
+// CollectAndClearLocaleEnvs stores current locale envs for child processes that
+// still need them, then clears them from the daemon process environment.
+func CollectAndClearLocaleEnvs() {
+	OriginalLocaleEnvs = nil
+	for _, localeEnvName := range []string{"LC_ALL", "LANGUAGE", "LC_MESSAGES", "LANG"} {
+		localeEnvValue, exists := os.LookupEnv(localeEnvName)
+		if exists {
+			OriginalLocaleEnvs = append(OriginalLocaleEnvs, localeEnvName+"="+localeEnvValue)
+		}
+		_ = utils.UnsetEnv(localeEnvName)
+	}
 }
 
 func DecodeJson(fpath string, d interface{}) error {

--- a/src/internal/system/common_test.go
+++ b/src/internal/system/common_test.go
@@ -5,6 +5,7 @@
 package system
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,4 +32,52 @@ func Test_GetCategorySourceMap(t *testing.T) {
 	SetSystemUpdate(false)
 	sourceMap = GetCategorySourceMap()
 	assert.Equal(t, SoftLinkSystemSourceDir, sourceMap[SystemUpdate])
+}
+
+func TestCollectAndClearLocaleEnvs(t *testing.T) {
+	oldOriginalLocaleEnvs := OriginalLocaleEnvs
+	originalValues := make(map[string]*string)
+	localeEnvNames := []string{"LC_ALL", "LANGUAGE", "LC_MESSAGES", "LANG"}
+
+	for _, name := range localeEnvNames {
+		value, exists := os.LookupEnv(name)
+		if exists {
+			valueCopy := value
+			originalValues[name] = &valueCopy
+		} else {
+			originalValues[name] = nil
+		}
+	}
+
+	t.Cleanup(func() {
+		OriginalLocaleEnvs = oldOriginalLocaleEnvs
+		for _, name := range localeEnvNames {
+			value := originalValues[name]
+			if value == nil {
+				_ = os.Unsetenv(name)
+				continue
+			}
+			_ = os.Setenv(name, *value)
+		}
+	})
+
+	OriginalLocaleEnvs = nil
+	assert.NoError(t, os.Setenv("LC_ALL", "zh_CN.UTF-8"))
+	assert.NoError(t, os.Setenv("LANGUAGE", "zh_CN:en_US"))
+	assert.NoError(t, os.Setenv("LC_MESSAGES", "zh_CN.UTF-8"))
+	assert.NoError(t, os.Setenv("LANG", "zh_CN.UTF-8"))
+
+	CollectAndClearLocaleEnvs()
+
+	assert.Equal(t, []string{
+		"LC_ALL=zh_CN.UTF-8",
+		"LANGUAGE=zh_CN:en_US",
+		"LC_MESSAGES=zh_CN.UTF-8",
+		"LANG=zh_CN.UTF-8",
+	}, OriginalLocaleEnvs)
+
+	for _, name := range localeEnvNames {
+		_, exists := os.LookupEnv(name)
+		assert.False(t, exists, name)
+	}
 }

--- a/src/lastore-daemon/common.go
+++ b/src/lastore-daemon/common.go
@@ -28,7 +28,6 @@ import (
 	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system/apt"
-	"github.com/linuxdeepin/lastore-daemon/src/internal/utils"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -147,24 +146,6 @@ func getLang(envVars procfs.EnvVars) string {
 		}
 	}
 	return ""
-}
-
-var originalLocaleEnvs []string
-
-// collectAndClearLocaleEnvs collects current locale environment variables,
-// clears them from the environment, and stores the original values for later use
-func collectAndClearLocaleEnvs() {
-	originalLocaleEnvs = nil
-	// Iterate over the list of environment variable names related to locale settings
-	for _, localeEnvName := range []string{"LC_ALL", "LANGUAGE",
-		"LC_MESSAGES", "LANG"} {
-		localeEnvValue, exists := os.LookupEnv(localeEnvName)
-		if exists {
-			// Store the original locale environment variables for later use
-			originalLocaleEnvs = append(originalLocaleEnvs, localeEnvName+"="+localeEnvValue)
-		}
-		_ = utils.UnsetEnv(localeEnvName)
-	}
 }
 
 func listPackageDesktopFiles(pkg string) []string {

--- a/src/lastore-daemon/immutable.go
+++ b/src/lastore-daemon/immutable.go
@@ -15,7 +15,7 @@ func (i *immutableManager) osTreeCmd(args []string) (out string, err error) {
 	if system.NormalFileExists(system.DeepinImmutableCtlPath) {
 		cmd := exec.Command(system.DeepinImmutableCtlPath, args...) // #nosec G204
 		cmd.Env = append(os.Environ(), "IMMUTABLE_DISABLE_REMOUNT=false")
-		cmd.Env = append(cmd.Env, originalLocaleEnvs...)
+		cmd.Env = append(cmd.Env, system.OriginalLocaleEnvs...)
 		logger.Info("run command:", cmd.Args)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout

--- a/src/lastore-daemon/main.go
+++ b/src/lastore-daemon/main.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	// Collect and clear locale environment variables
-	collectAndClearLocaleEnvs()
+	system.CollectAndClearLocaleEnvs()
 
 	gettext.InitI18n()
 	gettext.Textdomain("lastore-daemon")


### PR DESCRIPTION
Export CollectAndClearLocaleEnvs and OriginalLocaleEnvs to allow child processes (e.g. apt commands) to inherit locale environment variables from the daemon process.

将语言环境变量收集函数迁移至 system 包并导出，使子进程（如 apt 命令）
能够从守护进程继承语言环境变量。

Log: 将语言环境变量收集函数迁移至 system 包
PMS: BUG-361139
Influence: 子进程执行 apt 命令时可正确继承语言环境变量，确保输出信息语言一致。