### PR TITLE
fix(manager): fix initialization order to prevent nil pointer panic

### DIFF
--- a/src/lastore-daemon/main.go
+++ b/src/lastore-daemon/main.go
@@ -97,7 +97,6 @@ func main() {
 		logger.Error("failed to new server manager and updater object:", err)
 		return
 	}
-	manager.initAgent()
 	manager.initPlatformManager()
 	if config.IntranetUpdate {
 		//不再依赖检查更新或者online定时器触发，而是直接创建

--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -154,6 +154,7 @@ func NewManager(service *dbusutil.Service, updateApi system.System, c *config.Co
 	go func() {
 		m.setPropHardwareId(updateplatform.GetHardwareId(m.config.IncludeDiskInfo, m.config.GetHardwareIdByHelper))
 	}()
+	m.initAgent() // 先初始化 userAgents
 	m.initDbusSignalListen()
 	m.initDSettingsChangedHandle()
 	m.syncThirdPartyDconfig()
@@ -934,6 +935,11 @@ func (m *Manager) handleSessionNew(sessionId string, sessionPath dbus.ObjectPath
 
 	uidStr := strconv.Itoa(int(userInfo.UID))
 
+	if m.userAgents == nil {
+		logger.Warning("userAgents not initialized, skipping addSession")
+		return
+	}
+
 	newlyAdded := m.userAgents.addSession(uidStr, session)
 	if newlyAdded {
 		m.watchSession(uidStr, session)
@@ -942,6 +948,10 @@ func (m *Manager) handleSessionNew(sessionId string, sessionPath dbus.ObjectPath
 
 func (m *Manager) handleSessionRemoved(sessionId string, sessionPath dbus.ObjectPath) {
 	logger.Debug("session removed", sessionId, sessionPath)
+	if m.userAgents == nil {
+		logger.Warning("userAgents not initialized, skipping removeSession")
+		return
+	}
 	m.userAgents.removeSession(sessionPath)
 }
 


### PR DESCRIPTION
Move initAgent() call before initDbusSignalListen() in NewManager() to ensure userAgents is initialized before session signals are connected.

Also add defensive nil checks in handleSessionNew and handleSessionRemoved as a safety measure.

Bug: https://pms.uniontech.com/bug-view-361789.html