### PR TITLE
mirrors

### DIFF
--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -372,6 +372,18 @@
     "adjust_delay": 0
   },
   {
+    "id": "freedif",
+    "name": "[SG] Freedif Open Source Mirror",
+    "url": "https://mirror.freedif.org/deepin/deepin/",
+    "name_locale": {
+      "zh_CN": "[SG] Freedif 开源镜像站",
+      "zh_TW": "[SG] Freedif 開源鏡像站"
+    },
+    "weight": 59,
+    "country": "SG",
+    "adjust_delay": 0
+  },
+  {
     "id": "Tuxinator",
     "name": "Tuxinator",
     "url": "https://mirror2.tuxinator.org/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -360,6 +360,18 @@
     "adjust_delay": 0
   },
   {
+    "id": "qlu",
+    "name": "齐鲁工业大学",
+    "url": "https://mirrors.qlu.edu.cn/deepin/",
+    "name_locale": {
+      "zh_CN": "[CN] 齐鲁工业大学",
+      "zh_TW": "[CN] 齊魯工業大學"
+    },
+    "weight": 59,
+    "country": "CN",
+    "adjust_delay": 0
+  },
+  {
     "id": "Tuxinator",
     "name": "Tuxinator",
     "url": "https://mirror2.tuxinator.org/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -360,18 +360,6 @@
     "adjust_delay": 0
   },
   {
-    "id": "KDDI",
-    "name": "KDDI R&D Laboratories Inc.",
-    "url": "http://www.ftp.ne.jp/Linux/packages/deepin/deepin/",
-    "name_locale": {
-      "zh_CN": "KDDI R&D Laboratories Inc.",
-      "zh_TW": "KDDI R&D Laboratories Inc."
-    },
-    "weight": 58,
-    "country": "JP",
-    "adjust_delay": 0
-  },
-  {
     "id": "Tuxinator",
     "name": "Tuxinator",
     "url": "http://mirror2.tuxinator.org/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -360,18 +360,6 @@
     "adjust_delay": 0
   },
   {
-    "id": "tku",
-    "name": "Tamkang University",
-    "url": "http://ftp.tku.edu.tw/Linux/Deepin/deepin/",
-    "name_locale": {
-      "zh_CN": "[CN] 淡江大学",
-      "zh_TW": "[CN] 淡江大學"
-    },
-    "weight": 59,
-    "country": "CN",
-    "adjust_delay": 0
-  },
-  {
     "id": "KDDI",
     "name": "KDDI R&D Laboratories Inc.",
     "url": "http://www.ftp.ne.jp/Linux/packages/deepin/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -108,18 +108,6 @@
     "adjust_delay": 0
   },
   {
-    "id": "Crete",
-    "name": "[GR] University of Crete",
-    "url": "https://ftp.cc.uoc.gr/mirrors/linux/deepin/packages/",
-    "name_locale": {
-      "zh_CN": "[GR] 克里特大学",
-      "zh_TW": "[GR] 克裡特大學"
-    },
-    "weight": 17500,
-    "country": "GR",
-    "adjust_delay": 0
-  },
-  {
     "id": "NLUUG",
     "name": "[NL] NLUUG",
     "url": "https://ftp.nluug.nl/os/Linux/distr/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -14,7 +14,7 @@
   {
     "id": "Kernel",
     "name": "[US] Linux Kernel Archives",
-    "url": "http://mirrors.kernel.org/deepin/",
+    "url": "https://mirrors.kernel.org/deepin/",
     "name_locale": {
       "zh_CN": "[US] Linux 内核归档",
       "zh_TW": "[US] Linux 內核歸檔"
@@ -26,7 +26,7 @@
   {
     "id": "Aliyun",
     "name": "[CN] Aliyun",
-    "url": "http://mirrors.aliyun.com/deepin/",
+    "url": "https://mirrors.aliyun.com/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 阿里云",
       "zh_TW": "[CN] 阿裏雲"
@@ -50,7 +50,7 @@
   {
     "id": "HUST",
     "name": "[CN] HUST",
-    "url": "http://mirrors.hust.edu.cn/deepin/",
+    "url": "https://mirrors.hust.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 华中科技大学",
       "zh_TW": "[CN] 華中科技大學"
@@ -62,7 +62,7 @@
   {
     "id": "NJU",
     "name": "[CN] NJU",
-    "url": "http://mirrors.nju.edu.cn/deepin/",
+    "url": "https://mirrors.nju.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 南京大学",
       "zh_TW": "[CN] 南京大學"
@@ -74,7 +74,7 @@
   {
     "id": "JLU",
     "name": "[CN] JLU",
-    "url": "http://mirrors.jlu.edu.cn/deepin/",
+    "url": "https://mirrors.jlu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 吉林大学",
       "zh_TW": "[CN] 吉林大學"
@@ -98,7 +98,7 @@
   {
     "id": "UOEN",
     "name": "[DE] University of Erlangen-Nuremberg",
-    "url": "http://ftp.uni-erlangen.de/deepin/",
+    "url": "https://ftp.uni-erlangen.de/deepin/",
     "name_locale": {
       "zh_CN": "[DE] 埃尔朗根-纽伦堡大学",
       "zh_TW": "[DE] 埃爾朗根-紐倫堡大學"
@@ -110,7 +110,7 @@
   {
     "id": "Crete",
     "name": "[GR] University of Crete",
-    "url": "http://ftp.cc.uoc.gr/mirrors/linux/deepin/packages/",
+    "url": "https://ftp.cc.uoc.gr/mirrors/linux/deepin/packages/",
     "name_locale": {
       "zh_CN": "[GR] 克里特大学",
       "zh_TW": "[GR] 克裡特大學"
@@ -134,7 +134,7 @@
   {
     "id": "SNT",
     "name": "[NL] Universiteit Twente",
-    "url": "http://ftp.snt.utwente.nl/pub/os/linux/deepin/",
+    "url": "https://ftp.snt.utwente.nl/pub/os/linux/deepin/",
     "name_locale": {
       "zh_CN": "[NL] 特文特大学",
       "zh_TW": "[NL] 特文特大學"
@@ -146,7 +146,7 @@
   {
     "id": "Princeton University",
     "name": "Princeton University",
-    "url": "http://mirror.math.princeton.edu/pub/deepin/",
+    "url": "https://mirror.math.princeton.edu/pub/deepin/",
     "name_locale": {
       "zh_CN": "[US] 普林斯顿大学",
       "zh_TW": "[US] 普林斯頓大學"
@@ -158,7 +158,7 @@
   {
     "id": "ZJU",
     "name": "[CN] Zhejiang University",
-    "url": "http://mirrors.zju.edu.cn/deepin/",
+    "url": "https://mirrors.zju.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 浙江大学",
       "zh_TW": "[CN] 浙江大學 "
@@ -194,7 +194,7 @@
   {
     "id": "Datautama",
     "name": "[ID] Datautama Net Id Company",
-    "url": "http://kartolo.sby.datautama.net.id/deepin/",
+    "url": "https://kartolo.sby.datautama.net.id/deepin/",
     "name_locale": {
       "zh_CN": "[ID] Datautama Net Id Company",
       "zh_TW": "[ID] Datautama Net Id Company"
@@ -206,7 +206,7 @@
   {
     "id": "GARR",
     "name": "[IT] GARR MIRROR",
-    "url": "http://deepin.mirror.garr.it/mirrors/deepin/",
+    "url": "https://deepin.mirror.garr.it/mirrors/deepin/",
     "name_locale": {
       "zh_CN": "[IT] GARR MIRROR",
       "zh_TW": "[IT] GARR MIRROR"
@@ -218,7 +218,7 @@
   {
     "id": "JAIST",
     "name": "[JP] JAIST",
-    "url": "http://ftp.jaist.ac.jp/pub/Linux/deepin/",
+    "url": "https://ftp.jaist.ac.jp/pub/Linux/deepin/",
     "name_locale": {
       "zh_CN": "[JP] 北陆先端科学技术大学院大学",
       "zh_TW": "[JP] 北陸先端科學技術大學院大學"
@@ -230,7 +230,7 @@
   {
     "id": "Tsukuba",
     "name": "[JP] Tsukuba WIDE Public Mirror",
-    "url": "http://ftp.tsukuba.wide.ad.jp/Linux/deepin/",
+    "url": "https://ftp.tsukuba.wide.ad.jp/Linux/deepin/",
     "name_locale": {
       "zh_CN": "[JP] 筑波大学 WIDE 公共镜像",
       "zh_TW": "[JP] 筑波大學 WIDE 公共鏡像"
@@ -242,7 +242,7 @@
   {
     "id": "Rainside",
     "name": "[SK] Rainside",
-    "url": "http://tux.rainside.sk/deepin/",
+    "url": "https://tux.rainside.sk/deepin/",
     "name_locale": {
       "zh_CN": "[SK] Rainside",
       "zh_TW": "[SK] Rainside"
@@ -254,7 +254,7 @@
   {
     "id": "Alpix",
     "name": "Alpix",
-    "url": "http://mirror.alpix.eu/deepin/",
+    "url": "https://mirror.alpix.eu/deepin/",
     "name_locale": {
       "zh_CN": "Alpix",
       "zh_TW": "Alpix"
@@ -266,7 +266,7 @@
   {
     "id": "Dotsrc.",
     "name": "dotsrc",
-    "url": "http://mirrors.dotsrc.org/deepin/",
+    "url": "https://mirrors.dotsrc.org/deepin/",
     "name_locale": {
       "zh_CN": "dotsrc",
       "zh_TW": "dotsrc"
@@ -278,7 +278,7 @@
   {
     "id": "ACC",
     "name": "Academic Computer Club",
-    "url": "http://ftp.acc.umu.se/mirror/linuxdeepin/packages/",
+    "url": "https://ftp.acc.umu.se/mirror/linuxdeepin/packages/",
     "name_locale": {
       "zh_CN": "Academic Computer Club",
       "zh_TW": "Academic Computer Club"
@@ -302,7 +302,7 @@
   {
     "id": "Lysator",
     "name": "Lysator ACS",
-    "url": "http://ftp.lysator.liu.se/pub/deepin/packages/",
+    "url": "https://ftp.lysator.liu.se/pub/deepin/packages/",
     "name_locale": {
       "zh_CN": "Lysator ACS",
       "zh_TW": "Lysator ACS"
@@ -314,7 +314,7 @@
   {
     "id": "CEDIA",
     "name": "CEDIA",
-    "url": "http://mirror.cedia.org.ec/deepin/",
+    "url": "https://mirror.cedia.org.ec/deepin/",
     "name_locale": {
       "zh_CN": "CEDIA",
       "zh_TW": "CEDIA"
@@ -326,7 +326,7 @@
   {
     "id": "sjtu-edu",
     "name": "上海交通大学",
-    "url": "http://ftp.sjtu.edu.cn/deepin/",
+    "url": "https://ftp.sjtu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 上海交通大学",
       "zh_TW": "[CN] 上海交通大学"
@@ -338,7 +338,7 @@
   {
     "id": "lzu",
     "name": "兰州大学",
-    "url": "http://mirror.lzu.edu.cn/deepin/",
+    "url": "https://mirror.lzu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 兰州大学",
       "zh_TW": "[CN] 兰州大學"
@@ -350,7 +350,7 @@
   {
     "id": "cqu",
     "name": "重庆大学",
-    "url": "http://mirrors.cqu.edu.cn/deepin/",
+    "url": "https://mirrors.cqu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 重庆大学",
       "zh_TW": "[CN] 重庆大學"
@@ -362,7 +362,7 @@
   {
     "id": "Tuxinator",
     "name": "Tuxinator",
-    "url": "http://mirror2.tuxinator.org/deepin/",
+    "url": "https://mirror2.tuxinator.org/deepin/",
     "name_locale": {
       "zh_CN": "Tuxinator",
       "zh_TW": "Tuxinator"
@@ -386,7 +386,7 @@
   {
     "id": "GWDG",
     "name": "GWDG",
-    "url": "http://ftp.gwdg.de/pub/linux/linuxdeepin/deepin/",
+    "url": "https://ftp.gwdg.de/pub/linux/linuxdeepin/deepin/",
     "name_locale": {
       "zh_CN": "GWDG",
       "zh_TW": "GWDG"
@@ -410,7 +410,7 @@
   {
     "id": "Belnet",
     "name": "[BE] Belnet",
-    "url": "http://ftp.belnet.be/mirror/deepin/",
+    "url": "https://ftp.belnet.be/mirror/deepin/",
     "name_locale": {
       "zh_CN": "Belnet",
       "zh_TW": "Belnet"
@@ -422,7 +422,7 @@
   {
     "id": "UFPR",
     "name": "[BR] Federal University of Parana",
-    "url": "http://deepin.c3sl.ufpr.br/deepin/",
+    "url": "https://deepin.c3sl.ufpr.br/deepin/",
     "name_locale": {
       "zh_CN": "[BR] 巴拉那联邦大学",
       "zh_TW": "[BR] 巴拉那聯邦大學"
@@ -434,7 +434,7 @@
   {
     "id": "CLUG",
     "name": "[CZ] Czech Linux Users' Group",
-    "url": "http://ftp.linux.cz/pub/linux/deepin/",
+    "url": "https://ftp.linux.cz/pub/linux/deepin/",
     "name_locale": {
       "zh_CN": "[CZ] 捷克 Linux 用户组",
       "zh_TW": "[CZ] 捷克 Linux 使用者群組"
@@ -446,7 +446,7 @@
   {
     "id": "Foi",
     "name": "[CZ] Faculty of Informatics",
-    "url": "http://ftp.fi.muni.cz/pub/linux/deepin/",
+    "url": "https://ftp.fi.muni.cz/pub/linux/deepin/",
     "name_locale": {
       "zh_CN": "[CZ] 马萨里克大学信息学院",
       "zh_TW": "[CZ] 馬薩里克大學資訊學院"
@@ -458,7 +458,7 @@
   {
     "id": "CEDIA1",
     "name": "[EC] CEDIA1",
-    "url": "http://mirror.ueb.edu.ec/deepin/",
+    "url": "https://mirror.ueb.edu.ec/deepin/",
     "name_locale": {
       "zh_CN": "CEDIA1",
       "zh_TW": "CEDIA1"
@@ -470,7 +470,7 @@
   {
     "id": "IRCAM",
     "name": "[FR] IRCAM",
-    "url": "http://mirrors.ircam.fr/pub/deepin/",
+    "url": "https://mirrors.ircam.fr/pub/deepin/",
     "name_locale": {
       "zh_CN": "IRCAM",
       "zh_TW": "IRCAM"
@@ -494,7 +494,7 @@
   {
     "id": "IP-Connect",
     "name": "[UA] IP-Connect",
-    "url": "http://deepin.ip-connect.vn.ua/",
+    "url": "https://deepin.ip-connect.vn.ua/",
     "name_locale": {
       "zh_CN": "IP-Connect",
       "zh_TW": "IP-Connect"

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -372,18 +372,6 @@
     "adjust_delay": 0
   },
   {
-    "id": "GR",
-    "name": "[GR]University of Crete Computer Center ",
-    "url": "http://ftp.cc.uoc.gr/mirrors/linux/deepin/packages/",
-    "name_locale": {
-      "zh_CN": "[GR]克里特大学计算机中心",
-      "zh_TW": "[GR]克裏特大學計算機中心"
-    },
-    "weight": -1,
-    "country": "GR",
-    "adjust_delay": 0
-  },
-  {
     "id": "GTlib",
     "name": "[US] Georgia Institute of Technology",
     "url": "http://www.gtlib.gatech.edu/pub/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -348,6 +348,18 @@
     "adjust_delay": 0
   },
   {
+    "id": "nyist",
+    "name": "南阳理工学院",
+    "url": "https://mirror.nyist.edu.cn/deepin/",
+    "name_locale": {
+      "zh_CN": "[CN] 南阳理工学院",
+      "zh_TW": "[CN] 南陽理工學院"
+    },
+    "weight": 59,
+    "country": "CN",
+    "adjust_delay": 0
+  },
+  {
     "id": "Tuxinator",
     "name": "Tuxinator",
     "url": "https://mirror2.tuxinator.org/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -252,18 +252,6 @@
     "adjust_delay": 0
   },
   {
-    "id": "Quantum Mirror",
-    "name": "Quantum Mirror",
-    "url": "http://quantum-mirror.hu/mirrors/pub/deepin/",
-    "name_locale": {
-      "zh_CN": "Quantum Mirror",
-      "zh_TW": "Quantum Mirror"
-    },
-    "weight": 91,
-    "country": "HU",
-    "adjust_delay": 0
-  },
-  {
     "id": "Alpix",
     "name": "Alpix",
     "url": "http://mirror.alpix.eu/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -468,6 +468,18 @@
     "adjust_delay": 0
   },
   {
+    "id": "cicku",
+    "name": "CICKU Mirror",
+    "url": "https://mirrors.cicku.me/deepin/",
+    "name_locale": {
+      "zh_CN": "CICKU镜像站",
+      "zh_TW": "CICKU镜像站"
+    },
+    "weight": 5000,
+    "country": "US",
+    "adjust_delay": 0
+  },
+  {
     "id": "CLUG",
     "name": "[CZ] Czech Linux Users' Group",
     "url": "https://ftp.linux.cz/pub/linux/deepin/",

--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -108,6 +108,18 @@
     "adjust_delay": 0
   },
   {
+    "id": "NETERRA",
+    "name": "[BG] Neterra Telecommunications",
+    "url": "https://mirrors.neterra.net/deepin/",
+    "name_locale": {
+      "zh_CN": "[BG] Neterra Telecommunications",
+      "zh_TW": "[BG] Neterra Telecommunications"
+    },
+    "weight": 17000,
+    "country": "BG",
+    "adjust_delay": 0
+  },
+  {
     "id": "NLUUG",
     "name": "[NL] NLUUG",
     "url": "https://ftp.nluug.nl/os/Linux/distr/deepin/",


### PR DESCRIPTION
- **Drop quantum-mirror.hu as they are shutting down**
- **Drop ftp.tku.edu.tw as they no longer provides deepin**
- **Drop www.ftp.ne.jp as KDDI Research FTP Server discontinued**
- **Delete duplicate ftp.cc.uoc.gr**
- **Use https instead of http when supported**
- **Drop ftp.cc.uoc.gr as they no longer provides deepin**
- **Add mirror.nyist.edu.cn**
- **Add mirrors.qlu.edu.cn**
- **Add mirror.freedif.org**
- **Add mirrors.neterra.net**
- **Add mirrors.cicku.me**

## Summary by Sourcery

Update mirror configuration to remove deprecated sources, add new mirrors, and prefer HTTPS where available.

Enhancements:
- Refresh mirror list by removing shutdown or unsupported mirrors, eliminating duplicates, and adding several new mirror endpoints.
- Switch supported mirror URLs from HTTP to HTTPS to improve security of package downloads.