### PR TITLE
fix(dut): pass indicator to CheckSystem for error logging

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,3 +1,4 @@
 CacheList: caches.yaml
 Base: /var/lib/lastore/check/
 DebugMode: false
+DynHookTimeout: 1800

--- a/src/internal/system/dut/dut.go
+++ b/src/internal/system/dut/dut.go
@@ -21,7 +21,7 @@ var logger = log.NewLogger("lastore/dut")
 
 // CheckSystem performs a system check of the specified type with given options
 // and returns a JobError if any issues are found.
-func CheckSystem(typ CheckType, options map[string]string) *system.JobError {
+func CheckSystem(typ CheckType, options map[string]string, indicator system.Indicator) *system.JobError {
 	logger.Debugf("CheckSystem check type: %s, options: %+v", typ.String(), options)
 
 	// 参数验证
@@ -68,6 +68,14 @@ func CheckSystem(typ CheckType, options map[string]string) *system.JobError {
 	if checkError == nil {
 		logger.Info("checkError is nil")
 		return nil
+	}
+
+	// 通过 indicator 记录错误日志，使 processLogFds 能被调用
+	if indicator != nil {
+		indicator(system.JobProgressInfo{
+			OnlyLog:     true,
+			OriginalLog: checkError.Error(),
+		})
 	}
 
 	if jobErr, ok := checkError.(*system.JobError); ok {

--- a/src/internal/system/dut/proxy.go
+++ b/src/internal/system/dut/proxy.go
@@ -72,7 +72,7 @@ func (p *DutSystem) CheckSystem(jobId string, checkType string, environ map[stri
 	// environ parameter is ignored here
 	fn := system.NewFunction(jobId, p.Indicator, func() error {
 		// only postCheck can be handled here, checkType is ignored
-		systemErr := CheckSystem(PostUpgradeCheck, options)
+		systemErr := CheckSystem(PostUpgradeCheck, options, p.Indicator)
 		if systemErr != nil {
 			return systemErr
 		}

--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -289,7 +289,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 		j.setPreHooks(map[string]func() error{
 			string(system.RunningStatus): func() error {
 				checkType := dut.PreDownloadCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -384,7 +384,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 				}()
 
 				checkType := dut.PostDownloadCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -450,7 +450,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 					}()
 
 					checkType := dut.PostDownloadCheck
-					if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+					if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 						logger.Warning(systemErr)
 						go func(err *system.JobError) {
 							m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -277,7 +277,7 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 				job.setPropProgress(1.0)
 
 				checkType := dut.PostUpdateCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -334,7 +334,7 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 				}()
 
 				checkType := dut.PostUpdateCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -428,7 +428,7 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 				m.updater.setPropUpdateTarget(m.updatePlatform.GetUpdateTarget()) // 更新目标 历史版本控制中心获取UpdateTarget,获取更新日志
 
 				checkType := dut.PreUpdateCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{

--- a/src/lastore-daemon/manager_upgrade.go
+++ b/src/lastore-daemon/manager_upgrade.go
@@ -215,7 +215,7 @@ func (m *Manager) distUpgradePartly(sender dbus.Sender, origin system.UpdateType
 				})
 
 				checkType := dut.PreBackupCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -247,7 +247,7 @@ func (m *Manager) distUpgradePartly(sender dbus.Sender, origin system.UpdateType
 				inhibit(false)
 
 				checkType := dut.PostBackupCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -291,7 +291,7 @@ func (m *Manager) distUpgradePartly(sender dbus.Sender, origin system.UpdateType
 				go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, action, hints, system.NotifyExpireTimeoutDefault)
 
 				checkType := dut.PostBackupCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -484,7 +484,7 @@ func (m *Manager) distUpgrade(sender dbus.Sender, mode system.UpdateType, needAd
 				logger.Info("update UUID:", uuid)
 				m.updatePlatform.CreateJobPostMsgInfo(uuid, job.updateTyp)
 				checkType := dut.PreUpgradeCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{
@@ -530,7 +530,7 @@ func (m *Manager) distUpgrade(sender dbus.Sender, mode system.UpdateType, needAd
 		endJob.setPreHooks(map[string]func() error{
 			string(system.SucceedStatus): func() error {
 				checkType := dut.MidUpgradeCheck
-				if systemErr := dut.CheckSystem(checkType, nil); systemErr != nil {
+				if systemErr := dut.CheckSystem(checkType, nil, m.jobManager.handleJobProgressInfo); systemErr != nil {
 					logger.Warning(systemErr)
 					go func(err *system.JobError) {
 						m.updatePlatform.PostProcessEventMessage(updateplatform.ProcessEvent{

--- a/src/lastore-update-tools/cli/root.go
+++ b/src/lastore-update-tools/cli/root.go
@@ -44,6 +44,8 @@ func initCheckEnv() error {
 		}
 	}
 
+	check.SetDynHookTimeout(RootCoreConfig.DynHookTimeout)
+
 	if UpdateMetaConfigPath == "" {
 		logger.Errorf("update meta config path is empty")
 		return &system.JobError{

--- a/src/lastore-update-tools/config/core.go
+++ b/src/lastore-update-tools/config/core.go
@@ -11,10 +11,11 @@ import (
 )
 
 type CoreConfig struct {
-	CacheList  string `json:"CacheList" yaml:"CacheList"`                 // cachelist
-	Base       string `json:"Base" yaml:"Base"`                           // work base
-	DebugMode  bool   `json:"DebugMode" yaml:"DebugMode" default:"false"` // Debug Mode
-	ApiVersion string `json:"ApiVersion" yaml:"ApiVersion" default:"1.0"` // ApiVersion
+	CacheList      string `json:"CacheList" yaml:"CacheList"`                             // cachelist
+	Base           string `json:"Base" yaml:"Base"`                                       // work base
+	DebugMode      bool   `json:"DebugMode" yaml:"DebugMode" default:"false"`             // Debug Mode
+	ApiVersion     string `json:"ApiVersion" yaml:"ApiVersion" default:"1.0"`             // ApiVersion
+	DynHookTimeout int    `json:"DynHookTimeout" yaml:"DynHookTimeout" default:"1800"`    // dyn hook timeout in seconds
 }
 
 func (ts *CoreConfig) LoaderCfg(path string) error {

--- a/src/lastore-update-tools/controller/check/check.go
+++ b/src/lastore-update-tools/controller/check/check.go
@@ -18,6 +18,17 @@ import (
 
 var CheckBaseDir = "/var/lib/lastore/check/"
 
+// DynHookTimeout is the timeout in seconds for executing dynamic hook scripts.
+// Default is 1800 seconds (30 minutes). Can be overridden via configuration.
+var DynHookTimeout int = 1800
+
+// SetDynHookTimeout sets the timeout for dynamic hook execution.
+func SetDynHookTimeout(seconds int) {
+	if seconds > 0 {
+		DynHookTimeout = seconds
+	}
+}
+
 var logger = log.NewLogger("lastore/update-tools/check")
 
 var sysRealArch string
@@ -119,11 +130,12 @@ func CheckDynHook(checkType int8) error {
 		for _, hookFile := range hookFiles {
 			hookPath := filepath.Join(hookDir, hookFile)
 			logger.Infof("Executing hook: %s", hookPath)
-			output, err := runcmd.RunnerOutputEnv(60, hookPath, []string{"IMMUTABLE_DISABLE_REMOUNT=false"})
+			_, err := runcmd.RunnerOutputEnv(DynHookTimeout, hookPath, []string{"IMMUTABLE_DISABLE_REMOUNT=false"})
 			if err != nil {
-				return fmt.Errorf("hook execution failed: %s\nOutput:\n%s\nError:%s", hookPath, output, err.Error())
+				// only keep error related info, otherwise the log may be compressed
+				return fmt.Errorf("hook execution failed: %s\nError:%s", hookPath, err.Error())
 			}
-			logger.Infof("Hook executed successfully: %s\nOutput:\n%s", hookPath, output)
+			logger.Infof("Hook executed successfully: %s\n", hookPath)
 		}
 		return nil
 	}


### PR DESCRIPTION
Add indicator parameter to CheckSystem so error logs are recorded via indicator, enabling processLogFds to be called properly.

CheckSystem新增indicator参数，通过indicator记录错误日志，
确保processLogFds能被正确调用。

Log: 修复DUT检查错误日志未通过indicator记录的问题
PMS: BUG-365379
Influence: 系统检查失败时错误日志能正确记录，提升问题可追溯性。