### PR TITLE
fix: prevent path injection in temp file handling

### DIFF
--- a/src/lastore-daemon/common.go
+++ b/src/lastore-daemon/common.go
@@ -439,6 +439,38 @@ const (
 	coreListPkgName = "deepin-package-list"
 )
 
+// containsPathTraversal 检查 dpkg-deb -c 输出中是否存在路径穿越
+// dpkg-deb -c 输出格式: perms owner/group size date time path
+func containsPathTraversal(dpkgOutput string) bool {
+	lines := strings.Split(dpkgOutput, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// 提取路径：最后一个空格分隔的字段
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		entryPath := fields[len(fields)-1]
+
+		// 检查绝对路径
+		if path.IsAbs(entryPath) {
+			logger.Warningf("deb contains absolute path: %s", entryPath)
+			return true
+		}
+
+		// 检查路径穿越：清理后以 ../ 开头或包含 ../
+		cleaned := path.Clean(entryPath)
+		if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+			logger.Warningf("deb contains path traversal: %s (cleaned: %s)", entryPath, cleaned)
+			return true
+		}
+	}
+	return false
+}
+
 // 下载并解压coreList
 func downloadAndDecompressCoreList() (string, error) {
 	downloadPackages := []string{coreListPkgName}
@@ -470,12 +502,24 @@ func downloadAndDecompressCoreList() (string, error) {
 	}
 	var debFile string
 	for _, file := range files {
-		if strings.HasPrefix(file.Name(), coreListPkgName) && strings.HasSuffix(file.Name(), ".deb") {
-			debFile = filepath.Join(downloadPkg, file.Name())
+		name := file.Name()
+
+		if strings.HasPrefix(name, coreListPkgName) && strings.HasSuffix(name, ".deb") {
+			debFile = filepath.Join(downloadPkg, name)
 			break
 		}
 	}
 	if debFile != "" {
+		// 解压前检查包内容，防止路径穿越
+		checkCmd := exec.Command("dpkg-deb", "-c", debFile)
+		checkOutput, err := checkCmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to inspect deb contents: %v", err)
+		}
+		if containsPathTraversal(string(checkOutput)) {
+			return "", fmt.Errorf("deb package %s contains path traversal entries", debFile)
+		}
+
 		tmpDir, err := os.MkdirTemp("/tmp", coreListPkgName+".XXXXXX")
 		if err != nil {
 			return "", err

--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -1013,15 +1013,24 @@ func (m *Manager) sendNotify(appName string, replacesId uint32, appIcon string, 
 		if app == updateNotifyShowOptional {
 			app = updateNotifyShow
 		}
-		actionsArg := "["
-		if len(actions) != 0 {
-			actionsArg = actionsArg + `"` + strings.Join(actions, `","`) + `"`
-		}
-		actionsArg = actionsArg + "]"
+		actionsJSON, _ := json.Marshal(actions)
+		actionsArg := string(actionsJSON)
 
 		var hintsList []string
 		for key, value := range hints {
-			hintsList = append(hintsList, `"`+key+`":<"`+value.Value().(string)+`">`)
+			s, ok := value.Value().(string)
+			if !ok {
+				logger.Warningf(
+					"unexpected hint value type: key=%s type=%T",
+					key,
+					value.Value(),
+				)
+				continue
+			}
+
+			keyJSON, _ := json.Marshal(key)
+			valueJSON, _ := json.Marshal(s)
+			hintsList = append(hintsList, string(keyJSON)+`:<`+string(valueJSON)+`>`)
 		}
 		hintsArg := "{" + strings.Join(hintsList, `,`) + "}"
 		timeout := expireTimeout

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/dde-api/polkit"
@@ -581,16 +580,23 @@ func (m *Manager) SetUpdateSources(sender dbus.Sender, updateType system.UpdateT
 			return dbusutil.ToError(errors.New("custom repo config is invalid"))
 		}
 		// 使用apt-get check 检查仓库时候合规
-		tmpList := fmt.Sprintf("/tmp/custom_repo_%v", time.Now().Unix())
-		err = os.WriteFile(tmpList, []byte(strings.Join(repoConfig, "\n")), 0600)
+		tmpFile, err := os.CreateTemp("/tmp", "custom_repo_*")
 		if err != nil {
 			logger.Warning(err)
 		} else {
-			o, err := exec.Command("/usr/bin/apt-get", "check", "-o", "Debug::NoLocking=1",
-				"-o", fmt.Sprintf("Dir::Etc::sourcelist=%v", tmpList), "-o", "Dir::Etc::SourceParts=/dev/null").CombinedOutput()
+			tmpList := tmpFile.Name()
+			defer os.Remove(tmpList)
+			_, err = tmpFile.Write([]byte(strings.Join(repoConfig, "\n")))
+			tmpFile.Close()
 			if err != nil {
-				logger.Warning("apt-get check error", string(o))
-				return dbusutil.ToError(fmt.Errorf("repo format error:%v", string(o)))
+				logger.Warning(err)
+			} else {
+				o, err := exec.Command("/usr/bin/apt-get", "check", "-o", "Debug::NoLocking=1",
+					"-o", fmt.Sprintf("Dir::Etc::sourcelist=%v", tmpList), "-o", "Dir::Etc::SourceParts=/dev/null").CombinedOutput()
+				if err != nil {
+					logger.Warning("apt-get check error", string(o))
+					return dbusutil.ToError(fmt.Errorf("repo format error:%v", string(o)))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Use os.CreateTemp for secure temp file creation and add path traversal validation to prevent directory escape attacks.

使用os.CreateTemp创建安全的临时文件，并添加路径遍历验证
以防止目录逃逸攻击。

Log: 修复临时文件处理中的路径注入安全漏洞
PMS: BUG-364727
     BUG-364721
Influence: 增强系统安全性，防止通过临时文件路径进行的攻击。