### PR TITLE
fix(manager): add authorization check to FixError method

### DIFF
--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -57,6 +57,13 @@ func (m *Manager) CleanJob(jobId string) *dbus.Error {
 
 func (m *Manager) FixError(sender dbus.Sender, errType string) (job dbus.ObjectPath, busErr *dbus.Error) {
 	m.service.DelayAutoQuit()
+
+	// root、特殊 uid 和 allow-caller 白名单直通，其余调用方走 polkit。
+	err := m.checkInvokePermission(sender)
+	if err != nil {
+		return "/", dbusutil.ToError(err)
+	}
+
 	jobObj, err := m.delFixError(sender, errType)
 	if err != nil {
 		return "/", dbusutil.ToError(err)


### PR DESCRIPTION
Verify caller UID and apply polkit authentication for non-trusted senders before processing FixError requests.

在 FixError 方法中添加调用方权限校验，对非可信发送方
执行 polkit 鉴权，防止未授权调用。

Log: FixError 方法添加调用方权限校验
PMS: BUG-364805
Influence: 非特权用户调用 FixError 时需通过 polkit 验证，
提升系统安全性，防止未授权的操作。