### PR TITLE
fix(security): prevent env var injection via whitelist

### DIFF
--- a/src/internal/system/command.go
+++ b/src/internal/system/command.go
@@ -17,6 +17,32 @@ import (
 	"syscall"
 )
 
+// allowedChildEnvKeys 允许传递给子进程的环境变量白名单
+// 防止恶意环境变量（如 LD_PRELOAD）注入导致提权
+var allowedChildEnvKeys = map[string]bool{
+	// 代理相关
+	"http_proxy":  true,
+	"https_proxy": true,
+	"ftp_proxy":   true,
+	"all_proxy":   true,
+	"no_proxy":    true,
+	"HTTP_PROXY":  true,
+	"HTTPS_PROXY": true,
+	"FTP_PROXY":   true,
+	"NO_PROXY":    true,
+	"ALL_PROXY":   true,
+	// 显示相关
+	"DISPLAY":    true,
+	"XAUTHORITY": true,
+	// 语言相关
+	"DEEPIN_LASTORE_LANG": true,
+	// PackageKit 相关
+	"PACKAGEKIT_CALLER_UID": true,
+	// 磐石相关
+	"IMMUTABLE_DISABLE_REMOUNT":           true,
+	"DEEPIN_IMMUTABLE_UPGRADE_APT_OPTION": true,
+}
+
 type CommandSet interface {
 	AddCMD(cmd *Command)
 	RemoveCMD(id string)
@@ -58,7 +84,6 @@ func (c *Command) SetEnv(envVarMap map[string]string) {
 		return
 	}
 
-	// Create a map from existing environment variables
 	envMap := make(map[string]string)
 	for _, env := range os.Environ() {
 		pair := strings.SplitN(env, "=", 2)
@@ -67,12 +92,13 @@ func (c *Command) SetEnv(envVarMap map[string]string) {
 		}
 	}
 
-	// Update with new values, overwriting existing keys
+	// 只更新白名单中的环境变量，阻止 LD_PRELOAD 等恶意变量注入
 	for key, value := range envVarMap {
-		envMap[key] = value
+		if allowedChildEnvKeys[key] {
+			envMap[key] = value
+		}
 	}
 
-	// Convert back to slice
 	envVarSlice := make([]string, 0, len(envMap))
 	for key, value := range envMap {
 		envVarSlice = append(envVarSlice, key+"="+value)

--- a/src/lastore-daemon/common.go
+++ b/src/lastore-daemon/common.go
@@ -35,6 +35,20 @@ var _urlReg = regexp.MustCompile(`^[ ]*deb .*((?:https?|ftp|file|p2p|delivery):/
 
 const lastoreGatherInfo = "lastoreGatherInfo"
 
+// allowedProxyKeys 代理环境变量白名单，防止 Session Agent 注入恶意环境变量（如 LD_PRELOAD）导致提权
+var allowedProxyKeys = map[string]bool{
+	"http_proxy":  true,
+	"https_proxy": true,
+	"ftp_proxy":   true,
+	"no_proxy":    true,
+	"all_proxy":   true,
+	"HTTP_PROXY":  true,
+	"HTTPS_PROXY": true,
+	"FTP_PROXY":   true,
+	"NO_PROXY":    true,
+	"ALL_PROXY":   true,
+}
+
 // 获取list文件或list.d文件夹中所有list文件的未被屏蔽的仓库地址
 func getUpgradeUrls(path string) []string {
 	var upgradeUrls []string
@@ -103,10 +117,16 @@ func makeEnvironWithSender(m *Manager, sender dbus.Sender) (map[string]string, e
 	var err error
 	agent := m.userAgents.getActiveLastoreAgent()
 	if agent != nil {
-		environ, err = agent.GetManualProxy(0)
+		proxyEnviron, err := agent.GetManualProxy(0)
 		if err != nil {
 			logger.Warning(err)
-			environ = make(map[string]string)
+		} else {
+			// 只保留白名单中的代理环境变量，防止注入 LD_PRELOAD 等恶意变量导致提权
+			for key, value := range proxyEnviron {
+				if allowedProxyKeys[key] {
+					environ[key] = value
+				}
+			}
 		}
 	}
 	pid, err := m.service.GetConnPID(string(sender))


### PR DESCRIPTION
Add environment variable whitelist to block LD_PRELOAD injection in Command.SetEnv and makeEnvironWithSender functions.

在 Command.SetEnv 和 makeEnvironWithSender 中添加环境变量白名单， 阻止 LD_PRELOAD 等恶意环境变量注入导致提权。

Log: 修复环境变量注入安全漏洞
PMS: BUG-364803 BUG-364799
Influence: 修复后仅允许白名单中的环境变量传递给子进程和代理，防止通过 LD_PRELOAD 注入实现提权。