### PR TITLE
chore: bump version to 6.2.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+lastore-daemon (6.2.60) unstable; urgency=medium
+
+  * fix(security): prevent env var injection via whitelist (#440)
+  * fix(manager): add authorization check to FixError method (#439)
+  * feat(upgrade): support --full-merge option for immutable deploy refresh
+  * fix(auth): replace binary path identification with isTrustedSender and polkit (#428)
+  * fix: prevent path injection in temp file handling (#438)
+  * fix(updater): add URL validation for mirror source configuration (#436)
+  * fix(dut): pass indicator to CheckSystem for error logging (#435)
+  * Fix mirrors (#433)
+  * Revert "Revert "feat(packaging): add delivery packages as recommends for Prof…" (#434)
+
+ -- zhaohui <wangzhaohui@uniontech.com>  Thu, 12 Jun 2026 10:00:00 +0800
+
 lastore-daemon (6.2.59) unstable; urgency=medium
 
   * Revert "feat(packaging): add delivery packages as recommends for Professional…" (#431)


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update Debian packaging metadata to reflect version 6.2.60.