### PR TITLE
chore: update to 6.2.61.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lastore-daemon (6.2.61) unstable; urgency=medium
+
+  * fix(upgrade): move osTreeRefresh after post-upgrade hooks to prevent rollback
+
+ -- electricface <songwentai@uniontech.com>  Thu, 18 Jun 2026 12:11:48 +0800
+
 lastore-daemon (6.2.60) unstable; urgency=medium
 
   * fix(security): prevent env var injection via whitelist (#440)


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Refresh debian/changelog entry to reflect version 6.2.61.