### PR TITLE
fix: remove redundant global flags from dsettings config

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -71,16 +71,15 @@ type Config struct {
 	IntranetUpdate        bool
 
 	// 缓存大小超出限制时的清理时间间隔
-	CleanIntervalCacheOverLimit    time.Duration
-	AppstoreRegion                 string
-	LastCheckTime                  time.Time
-	LastCleanTime                  time.Time
-	LastCheckCacheSizeTime         time.Time
-	Repository                     string
-	MirrorsUrl                     string
-	AllowInstallRemovePkgExecPaths []string
-	AutoInstallUpdates             bool
-	AutoInstallUpdateType          system.UpdateType
+	CleanIntervalCacheOverLimit time.Duration
+	AppstoreRegion              string
+	LastCheckTime               time.Time
+	LastCleanTime               time.Time
+	LastCheckCacheSizeTime      time.Time
+	Repository                  string
+	MirrorsUrl                  string
+	AutoInstallUpdates          bool
+	AutoInstallUpdateType       system.UpdateType
 
 	AllowPostSystemUpgradeMessageVersion []string // 只有数组内的系统版本被允许发送更新完成的数据
 
@@ -193,7 +192,6 @@ const (
 	dSettingsKeyLastCheckCacheSizeTime               = "last-check-cache-size-time"
 	dSettingsKeyRepository                           = "repository"
 	dSettingsKeyMirrorsUrl                           = "mirrors-url"
-	dSettingsKeyAllowInstallRemovePkgExecPaths       = "allow-install-remove-pkg-exec-paths"
 	dSettingsKeyAutoInstallUpdates                   = "auto-install-updates"
 	dSettingsKeyAutoInstallUpdateType                = "auto-install-update-type"
 	dSettingsKeyAllowPostSystemUpgradeMessageVersion = "allow-post-system-upgrade-message-version"
@@ -423,15 +421,6 @@ func getConfigFromDSettings() *Config {
 		logger.Warning(err)
 	} else {
 		c.MirrorsUrl = v.Value().(string)
-	}
-
-	v, err = c.dsLastoreManager.Value(0, dSettingsKeyAllowInstallRemovePkgExecPaths)
-	if err != nil {
-		logger.Warning(err)
-	} else {
-		for _, s := range v.Value().([]dbus.Variant) {
-			c.AllowInstallRemovePkgExecPaths = append(c.AllowInstallRemovePkgExecPaths, s.Value().(string))
-		}
 	}
 
 	v, err = c.dsLastoreManager.Value(0, dSettingsKeyAutoInstallUpdates)
@@ -963,7 +952,6 @@ func (c *Config) json2DSettings(oldConfig *Config) {
 	_ = c.SetCleanInterval(oldConfig.CleanInterval)
 	_ = c.SetRepository(oldConfig.Repository)
 	_ = c.SetMirrorsUrl(oldConfig.MirrorsUrl)
-	_ = c.SetAllowInstallRemovePkgExecPaths(append(oldConfig.AllowInstallRemovePkgExecPaths, c.AllowInstallRemovePkgExecPaths...))
 }
 
 func (c *Config) ConnectConfigChanged(key string, cb func(interface{}, interface{})) {
@@ -1107,11 +1095,6 @@ func (c *Config) SetRepository(repository string) error {
 func (c *Config) SetMirrorsUrl(mirrorsUrl string) error {
 	c.MirrorsUrl = mirrorsUrl
 	return c.save(dSettingsKeyMirrorsUrl, mirrorsUrl)
-}
-
-func (c *Config) SetAllowInstallRemovePkgExecPaths(paths []string) error {
-	c.AllowInstallRemovePkgExecPaths = paths
-	return c.save(dSettingsKeyAllowInstallRemovePkgExecPaths, paths)
 }
 
 // func (c *Config) SetNeedDownloadSize(size float64) error {

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -26,7 +26,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, err)
 	defer tmpfile.Close()
 
-	data := []byte(`{"Version":"0.1","AutoCheckUpdates":true,"DisableUpdateMetadata":false,"AutoDownloadUpdates":false,"AutoClean":true,"MirrorSource":"default","UpdateNotify":true,"CheckInterval":604800000000000,"CleanInterval":604800000000000,"UpdateMode":3,"CleanIntervalCacheOverLimit":86400000000000,"AppstoreRegion":"","LastCheckTime":"2021-06-17T14:10:21.896021304+08:00","LastCleanTime":"2021-06-17T09:18:31.515019638+08:00","LastCheckCacheSizeTime":"2021-06-17T09:18:31.5151104+08:00","Repository":"desktop","MirrorsUrl":"","AllowInstallRemovePkgExecPaths":null}`)
+	data := []byte(`{"Version":"0.1","AutoCheckUpdates":true,"DisableUpdateMetadata":false,"AutoDownloadUpdates":false,"AutoClean":true,"MirrorSource":"default","UpdateNotify":true,"CheckInterval":604800000000000,"CleanInterval":604800000000000,"UpdateMode":3,"CleanIntervalCacheOverLimit":86400000000000,"AppstoreRegion":"","LastCheckTime":"2021-06-17T14:10:21.896021304+08:00","LastCleanTime":"2021-06-17T09:18:31.515019638+08:00","LastCheckCacheSizeTime":"2021-06-17T09:18:31.5151104+08:00","Repository":"desktop","MirrorsUrl":""}`)
 	err = os.WriteFile(tmpfile.Name(), data, 0777)
 	require.NoError(t, err)
 

--- a/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
+++ b/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
@@ -5,9 +5,6 @@
     "use-dsettings": {
       "value": false,
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "UseDSettings",
       "description": "",
       "permissions": "readwrite",
@@ -16,9 +13,6 @@
     "version": {
       "value": "1.1",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "Version",
       "description": "",
       "permissions": "readonly",
@@ -222,17 +216,6 @@
       "permissions": "readwrite",
       "visibility": "private"
     },
-    "allow-install-remove-pkg-exec-paths": {
-      "value": [],
-      "serial": 0,
-      "flags": [
-        "global"
-      ],
-      "name": "AllowInstallRemovePkgExecPaths",
-      "description": "",
-      "permissions": "readwrite",
-      "visibility": "private"
-    },
     "auto-install-updates": {
       "value": false,
       "serial": 0,
@@ -304,9 +287,6 @@
     "system-sources": {
       "value": ["/etc/apt/sources.list","/etc/apt/sources.list.d/deepin-unstable-source.list","/etc/apt/sources.list.d/hwe.list"],
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "SystemSources",
       "description": "",
       "permissions": "readwrite",
@@ -512,9 +492,6 @@
     "upgrade-delivery-enabled": {
       "value": true,
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "UpgradeDeliveryEnabled",
       "description": "upgrade delivery enabled",
       "name[zh_CN]": "传递优化服务开机是否可用",
@@ -525,9 +502,6 @@
     "system-custom-source": {
       "value": [],
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "SystemCustomSource",
       "name[zh_CN]": "系统更新自定义仓库",
       "description": "system custom source",
@@ -538,9 +512,6 @@
     "security-custom-source": {
       "value": [],
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "SecurityCustomSource",
       "name[zh_CN]": "安全更新自定义仓库",
       "description": "security custom source",
@@ -551,9 +522,6 @@
     "system-repo-type": {
       "value": "UOS_DEFAULT",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "SystemRepoType",
       "name[zh_CN]": "系统更新仓库类型",
       "description": "system repo type",
@@ -564,9 +532,6 @@
     "security-repo-type": {
       "value": "UOS_DEFAULT",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "SecurityRepoType",
       "name[zh_CN]": "安全更新仓库类型",
       "description": "security repo type",
@@ -603,9 +568,6 @@
     "incremental-update": {
       "value": true,
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "IncrementalUpdate",
       "description": "Enable incremental update",
       "permissions": "readwrite",
@@ -614,9 +576,6 @@
     "intranet-update": {
       "value": false,
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "IntranetUpdate",
       "name[zh_CN]": "内网升级",
       "description[zh_CN]": "从内网升级平台获取更新",
@@ -627,9 +586,6 @@
     "delivery-remote-download-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryRemoteDownloadGlobalLimit",
       "name[zh_CN]": "远程下载全局限速",
       "description[zh_CN]": "传递优化远程下载全局限速配置",
@@ -640,9 +596,6 @@
     "delivery-remote-upload-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryRemoteUploadGlobalLimit",
       "name[zh_CN]": "远程上传全局限速",
       "description[zh_CN]": "传递优化远程上传全局限速配置",
@@ -653,9 +606,6 @@
     "delivery-remote-download-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryRemoteDownloadPeakLimit",
       "name[zh_CN]": "远程下载忙时限速",
       "description[zh_CN]": "传递优化远程下载忙时限速配置",
@@ -666,9 +616,6 @@
     "delivery-remote-upload-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryRemoteUploadPeakLimit",
       "name[zh_CN]": "远程上传忙时限速",
       "description[zh_CN]": "传递优化远程上传忙时限速配置",
@@ -679,9 +626,6 @@
     "delivery-remote-download-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryRemoteDownloadOffPeakLimit",
       "name[zh_CN]": "远程下载闲时限速",
       "description[zh_CN]": "传递优化远程下载闲时限速配置",
@@ -692,9 +636,6 @@
     "delivery-remote-upload-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryRemoteUploadOffPeakLimit",
       "name[zh_CN]": "远程上传闲时限速",
       "description[zh_CN]": "传递优化远程上传闲时限速配置",
@@ -705,9 +646,6 @@
     "delivery-local-download-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryLocalDownloadGlobalLimit",
       "name[zh_CN]": "本地下载全局限速",
       "description[zh_CN]": "传递优化本地下载全局限速配置",
@@ -718,9 +656,6 @@
     "delivery-local-upload-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryLocalUploadGlobalLimit",
       "name[zh_CN]": "本地上传全局限速",
       "description[zh_CN]": "传递优化本地上传全局限速配置",
@@ -731,9 +666,6 @@
     "delivery-local-download-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryLocalDownloadPeakLimit",
       "name[zh_CN]": "本地下载忙时限速",
       "description[zh_CN]": "传递优化本地下载忙时限速配置",
@@ -744,9 +676,6 @@
     "delivery-local-upload-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryLocalUploadPeakLimit",
       "name[zh_CN]": "本地上传忙时限速",
       "description[zh_CN]": "传递优化本地上传忙时限速配置",
@@ -757,9 +686,6 @@
     "delivery-local-download-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryLocalDownloadOffPeakLimit",
       "name[zh_CN]": "本地下载闲时限速",
       "description[zh_CN]": "传递优化本地下载闲时限速配置",
@@ -770,9 +696,6 @@
     "delivery-local-upload-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
       "serial": 0,
-      "flags": [
-        "global"
-      ],
       "name": "DeliveryLocalUploadOffPeakLimit",
       "name[zh_CN]": "本地上传闲时限速",
       "description[zh_CN]": "传递优化本地上传闲时限速配置",


### PR DESCRIPTION
The "flags": ["global"] entries were redundant across multiple dsettings keys (use-dsettings, version, system-sources, delivery limit configs, etc.). Remove them to simplify the configuration.

Bug: https://pms.uniontech.com/bug-view-368375.html

## Summary by Sourcery

Bug Fixes:
- Eliminate unnecessary "flags": ["global"] entries in dsettings keys to resolve configuration issues in lastore.