### PR TITLE
fix(config): bump serial for dsettings keys after global flags removal

### DIFF
--- a/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
+++ b/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
@@ -4,7 +4,7 @@
   "contents": {
     "use-dsettings": {
       "value": false,
-      "serial": 0,
+      "serial": 1,
       "name": "UseDSettings",
       "description": "",
       "permissions": "readwrite",
@@ -12,7 +12,7 @@
     },
     "version": {
       "value": "1.1",
-      "serial": 0,
+      "serial": 1,
       "name": "Version",
       "description": "",
       "permissions": "readonly",
@@ -286,7 +286,7 @@
     },
     "system-sources": {
       "value": ["/etc/apt/sources.list","/etc/apt/sources.list.d/deepin-unstable-source.list","/etc/apt/sources.list.d/hwe.list"],
-      "serial": 0,
+      "serial": 1,
       "name": "SystemSources",
       "description": "",
       "permissions": "readwrite",
@@ -491,7 +491,7 @@
     },
     "upgrade-delivery-enabled": {
       "value": true,
-      "serial": 0,
+      "serial": 1,
       "name": "UpgradeDeliveryEnabled",
       "description": "upgrade delivery enabled",
       "name[zh_CN]": "传递优化服务开机是否可用",
@@ -501,7 +501,7 @@
     },
     "system-custom-source": {
       "value": [],
-      "serial": 0,
+      "serial": 1,
       "name": "SystemCustomSource",
       "name[zh_CN]": "系统更新自定义仓库",
       "description": "system custom source",
@@ -511,7 +511,7 @@
     },
     "security-custom-source": {
       "value": [],
-      "serial": 0,
+      "serial": 1,
       "name": "SecurityCustomSource",
       "name[zh_CN]": "安全更新自定义仓库",
       "description": "security custom source",
@@ -521,7 +521,7 @@
     },
     "system-repo-type": {
       "value": "UOS_DEFAULT",
-      "serial": 0,
+      "serial": 1,
       "name": "SystemRepoType",
       "name[zh_CN]": "系统更新仓库类型",
       "description": "system repo type",
@@ -531,7 +531,7 @@
     },
     "security-repo-type": {
       "value": "UOS_DEFAULT",
-      "serial": 0,
+      "serial": 1,
       "name": "SecurityRepoType",
       "name[zh_CN]": "安全更新仓库类型",
       "description": "security repo type",
@@ -567,7 +567,7 @@
     },
     "incremental-update": {
       "value": true,
-      "serial": 0,
+      "serial": 1,
       "name": "IncrementalUpdate",
       "description": "Enable incremental update",
       "permissions": "readwrite",
@@ -575,7 +575,7 @@
     },
     "intranet-update": {
       "value": false,
-      "serial": 0,
+      "serial": 1,
       "name": "IntranetUpdate",
       "name[zh_CN]": "内网升级",
       "description[zh_CN]": "从内网升级平台获取更新",
@@ -585,7 +585,7 @@
     },
     "delivery-remote-download-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryRemoteDownloadGlobalLimit",
       "name[zh_CN]": "远程下载全局限速",
       "description[zh_CN]": "传递优化远程下载全局限速配置",
@@ -595,7 +595,7 @@
     },
     "delivery-remote-upload-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryRemoteUploadGlobalLimit",
       "name[zh_CN]": "远程上传全局限速",
       "description[zh_CN]": "传递优化远程上传全局限速配置",
@@ -605,7 +605,7 @@
     },
     "delivery-remote-download-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryRemoteDownloadPeakLimit",
       "name[zh_CN]": "远程下载忙时限速",
       "description[zh_CN]": "传递优化远程下载忙时限速配置",
@@ -615,7 +615,7 @@
     },
     "delivery-remote-upload-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryRemoteUploadPeakLimit",
       "name[zh_CN]": "远程上传忙时限速",
       "description[zh_CN]": "传递优化远程上传忙时限速配置",
@@ -625,7 +625,7 @@
     },
     "delivery-remote-download-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryRemoteDownloadOffPeakLimit",
       "name[zh_CN]": "远程下载闲时限速",
       "description[zh_CN]": "传递优化远程下载闲时限速配置",
@@ -635,7 +635,7 @@
     },
     "delivery-remote-upload-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryRemoteUploadOffPeakLimit",
       "name[zh_CN]": "远程上传闲时限速",
       "description[zh_CN]": "传递优化远程上传闲时限速配置",
@@ -645,7 +645,7 @@
     },
     "delivery-local-download-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryLocalDownloadGlobalLimit",
       "name[zh_CN]": "本地下载全局限速",
       "description[zh_CN]": "传递优化本地下载全局限速配置",
@@ -655,7 +655,7 @@
     },
     "delivery-local-upload-global-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryLocalUploadGlobalLimit",
       "name[zh_CN]": "本地上传全局限速",
       "description[zh_CN]": "传递优化本地上传全局限速配置",
@@ -665,7 +665,7 @@
     },
     "delivery-local-download-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryLocalDownloadPeakLimit",
       "name[zh_CN]": "本地下载忙时限速",
       "description[zh_CN]": "传递优化本地下载忙时限速配置",
@@ -675,7 +675,7 @@
     },
     "delivery-local-upload-peak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryLocalUploadPeakLimit",
       "name[zh_CN]": "本地上传忙时限速",
       "description[zh_CN]": "传递优化本地上传忙时限速配置",
@@ -685,7 +685,7 @@
     },
     "delivery-local-download-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryLocalDownloadOffPeakLimit",
       "name[zh_CN]": "本地下载闲时限速",
       "description[zh_CN]": "传递优化本地下载闲时限速配置",
@@ -695,7 +695,7 @@
     },
     "delivery-local-upload-offpeak-limit": {
       "value": "{\"LimitType\":0,\"StartTime\":\"0001-01-01T00:00:00Z\",\"EndTime\":\"0001-01-01T00:00:00Z\",\"LimitRate\":10485760,\"CurrentRate\":10485760}",
-      "serial": 0,
+      "serial": 1,
       "name": "DeliveryLocalUploadOffPeakLimit",
       "name[zh_CN]": "本地上传闲时限速",
       "description[zh_CN]": "传递优化本地上传闲时限速配置",


### PR DESCRIPTION
Increment the serial of the 22 keys whose "flags": ["global"] entries were removed in 981a6e8 so dsettings recognizes the configuration change (use-dsettings, version, system-sources, delivery limit keys, etc.).

Bug: https://pms.uniontech.com/bug-view-368375.html

## Summary by Sourcery

Bug Fixes:
- Ensure dsettings picks up configuration changes for keys whose global flags were removed by incrementing their serial values.