### PR TITLE
fix(dconfig): restore install-package-support-auth config entry

### DIFF
--- a/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
+++ b/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
@@ -62,6 +62,17 @@
       "permissions": "readwrite",
       "visibility": "private"
     },
+    "install-package-support-auth": {
+      "value": true,
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "InstallPackageSupportAuth",
+      "description": "Indicates that other applications can call this project's DBus interface to install packages",
+      "permissions": "readonly",
+      "visibility": "public"
+    },
     "mirror-source": {
       "value": "default",
       "serial": 0,


### PR DESCRIPTION
Restore the previously removed dsg config entry that indicates other
applications can call this project's DBus interface to install packages.

Log: 恢复 install-package-support-auth 配置项，允许其他应用通过 DBus 接口安装软件包
Influence: 相关应用的软件包安装

PMS: BUG-368579

## Summary by Sourcery

Bug Fixes:
- Reinstate the install-package-support-auth configuration flag so dependent applications can again install packages through the DBus interface.