### PR TITLE
chore: update changelog to 6.2.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+lastore-daemon (6.2.62) unstable; urgency=medium
+
+  * fix(dconfig): restore install-package-support-auth config entry
+  * fix(config): bump serial for dsettings keys after global flags
+    removal
+  * fix: remove redundant global flags from dsettings config
+
+ -- wangzhaohui <wangzhaohui@uniontech.com>  Fri, 17 Jul 2026 15:11:51 +0800
+
 lastore-daemon (6.2.61) unstable; urgency=medium
 
   * fix(upgrade): move osTreeRefresh after post-upgrade hooks to prevent rollback


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.2.62

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.2.62
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh debian/changelog to document the 6.2.62 release.