### PR TITLE
fix(manager): authorize rollback confirmation

### DIFF
--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -623,7 +623,11 @@ func (m *Manager) SetUpdateSources(sender dbus.Sender, updateType system.UpdateT
 }
 
 func (m *Manager) ConfirmRollback(sender dbus.Sender, confirm bool) *dbus.Error {
-	var err error
+	err := m.checkInvokePermission(sender)
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
+
 	if confirm {
 		needReboot := m.immutableManager.osTreeNeedRebootAfterRollback()
 		err = m.immutableManager.osTreeRollback()


### PR DESCRIPTION
Require invocation permission before confirming immutable rollback to prevent unauthorized rollback requests.

Log: 为 ConfirmRollback 增加调用权限校验，防止未授权回滚
Influence: 系统升级回退
PMS: BUG-370771

## Summary by Sourcery

Bug Fixes:
- Require invocation permission validation in ConfirmRollback to block unauthorized rollback confirmations.