### PR TITLE
fix(updater): add authorization check to SetInstallUpdateTime method

### DIFF
--- a/src/lastore-daemon/updater.go
+++ b/src/lastore-daemon/updater.go
@@ -350,6 +350,12 @@ func (u *Updater) listMirrorSources(lang string) []LocaleMirrorSource {
 func (u *Updater) SetInstallUpdateTime(sender dbus.Sender, timeStr string) *dbus.Error {
 	logger.Info("SetInstallUpdateTime", timeStr)
 
+	// root、特殊 uid 和 allow-caller 白名单直通，其余调用方走 polkit。
+	err := u.manager.checkInvokePermission(sender)
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
+
 	if len(timeStr) == 0 {
 		u.config.SetInstallUpdateTime(updateplatform.KeyNow)
 	} else if timeStr == updateplatform.KeyNow || timeStr == updateplatform.KeyShutdown {
@@ -367,7 +373,7 @@ func (u *Updater) SetInstallUpdateTime(sender dbus.Sender, timeStr string) *dbus
 		u.config.SetInstallUpdateTime(updateTime.Format(time.RFC3339))
 	}
 
-	_, err := u.manager.updateSource(sender) // 自动检查更新按照控制中心更新配置进行检查
+	_, err = u.manager.updateSource(sender) // 自动检查更新按照控制中心更新配置进行检查
 	if err != nil {
 		logger.Warning(err)
 		return dbusutil.ToError(err)


### PR DESCRIPTION
## Summary

为 `Updater.SetInstallUpdateTime` 方法添加调用方权限校验，与已有的 `FixError`（#439）及 `SetMirrorSource` 等方法保持一致的安全策略。

## Changes

- 在 `src/lastore-daemon/updater.go` 的 `SetInstallUpdateTime` 入口处调用 `u.manager.checkInvokePermission(sender)`。
- root、特殊 uid 及 allow-caller 白名单直通，其余非可信发送方走 polkit 鉴权（`polkitActionChangeOwnData`）。
- 将后续 `_, err :=` 调整为 `_, err =` 以避免与新增的 `err` 声明冲突导致编译错误。

## Verification

- `go build -mod=mod ./src/lastore-daemon/` 编译通过。
- `gofmt` 检查通过。

## Why

`SetInstallUpdateTime` 会修改安装更新时间配置并触发 `updateSource`，属于可影响系统更新行为的写操作。此前缺少鉴权，非特权用户可未授权调用。本次补齐权限校验，提升系统安全性。

Log: SetInstallUpdateTime 方法添加调用方权限校验
Influence: 非特权用户调用 SetInstallUpdateTime 时需通过 polkit 验证，提升系统安全性，防止未授权的操作。

## Summary by Sourcery

Add permission checks to SetInstallUpdateTime to align updater write operations with existing authorization policy.

Bug Fixes:
- Prevent unauthorized users from changing install update time by enforcing manager permission checks on SetInstallUpdateTime.

Enhancements:
- Align SetInstallUpdateTime with existing updater methods by routing non-whitelisted callers through polkit authorization.
