### PR TITLE
fix(security): add caller verification for CleanArchives/CleanJob/PauseJob/StartJob

### DIFF
--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -623,6 +623,18 @@ func (m *Manager) removePackage(sender dbus.Sender, jobName string, packages str
 	return job, nil
 }
 
+func (m *Manager) cleanJob(jobId string) error {
+	m.do.Lock()
+	err := m.jobManager.CleanJob(jobId)
+	// 在clean后需要执行一次dispatch,将end状态的job清除,防止重新创建时出现异常
+	m.jobManager.dispatch()
+	m.do.Unlock()
+	if err != nil {
+		logger.Warningf("CleanJob %q error: %v\n", jobId, err)
+	}
+	return err
+}
+
 func (m *Manager) cleanArchives(needNotify bool) (*Job, error) {
 	var jobName string
 	if needNotify {

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -33,8 +33,11 @@ NOTE: Most of export function of Manager will hold the lock,
 so don't invoke they in inner functions
 */
 
-func (m *Manager) CleanArchives() (job dbus.ObjectPath, busErr *dbus.Error) {
+func (m *Manager) CleanArchives(sender dbus.Sender) (job dbus.ObjectPath, busErr *dbus.Error) {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return "/", dbusutil.ToError(err)
+	}
 	jobObj, err := m.cleanArchives(false)
 	if err != nil {
 		return "/", dbusutil.ToError(err)
@@ -42,17 +45,12 @@ func (m *Manager) CleanArchives() (job dbus.ObjectPath, busErr *dbus.Error) {
 	return jobObj.getPath(), nil
 }
 
-func (m *Manager) CleanJob(jobId string) *dbus.Error {
+func (m *Manager) CleanJob(sender dbus.Sender, jobId string) *dbus.Error {
 	m.service.DelayAutoQuit()
-	m.do.Lock()
-	err := m.jobManager.CleanJob(jobId)
-	// 在clean后需要执行一次dispatch,将end状态的job清除,防止重新创建时出现异常
-	m.jobManager.dispatch()
-	m.do.Unlock()
-	if err != nil {
-		logger.Warningf("CleanJob %q error: %v\n", jobId, err)
+	if err := m.checkInvokePermission(sender); err != nil {
+		return dbusutil.ToError(err)
 	}
-	return dbusutil.ToError(err)
+	return dbusutil.ToError(m.cleanJob(jobId))
 }
 
 func (m *Manager) FixError(sender dbus.Sender, errType string) (job dbus.ObjectPath, busErr *dbus.Error) {
@@ -211,7 +209,11 @@ func (m *Manager) PackagesDownloadSize(packages []string) (int64, *dbus.Error) {
 	return int64(size), dbusutil.ToError(err)
 }
 
-func (m *Manager) PauseJob(jobId string) *dbus.Error {
+func (m *Manager) PauseJob(sender dbus.Sender, jobId string) *dbus.Error {
+	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return dbusutil.ToError(err)
+	}
 	m.do.Lock()
 	err := m.jobManager.PauseJob(jobId)
 	m.do.Unlock()
@@ -316,8 +318,11 @@ func (m *Manager) SetAutoClean(enable bool) *dbus.Error {
 	return nil
 }
 
-func (m *Manager) StartJob(jobId string) *dbus.Error {
+func (m *Manager) StartJob(sender dbus.Sender, jobId string) *dbus.Error {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return dbusutil.ToError(err)
+	}
 	m.do.Lock()
 	err := m.jobManager.MarkStart(jobId)
 	m.do.Unlock()

--- a/src/lastore-daemon/manager_unit.go
+++ b/src/lastore-daemon/manager_unit.go
@@ -311,7 +311,7 @@ func (m *Manager) handleAbortAutoDownload() {
 	}
 
 	logger.Debug("Abort auto download")
-	err := m.CleanJob(system.PrepareDistUpgradeJobType)
+	err := m.cleanJob(system.PrepareDistUpgradeJobType)
 	if err != nil {
 		logger.Warning(err)
 	}

--- a/src/lastore-daemon/manager_upgrade.go
+++ b/src/lastore-daemon/manager_upgrade.go
@@ -341,7 +341,7 @@ func (m *Manager) distUpgradePartly(sender dbus.Sender, origin system.UpdateType
 	defer func() {
 		// 没有开始更新提前结束时，需要处理抑制锁和job
 		if startJobErr != nil {
-			err = m.CleanJob(upgradeJob.Id)
+			err = m.cleanJob(upgradeJob.Id)
 			if err != nil {
 				logger.Warning(err)
 			}


### PR DESCRIPTION
为 CleanArchives、CleanJob、PauseJob、StartJob 增加 sender 参数与
checkInvokePermission 鉴权。将 CleanJob 的清理逻辑抽取为内部
cleanJob 方法，使 manager_unit.go、manager_upgrade.go 中的内部调用
绕过 DBus 鉴权检查。

PMS: BUG-370765

## Summary by Sourcery

Enforce caller permission checks for job and archive management operations while allowing trusted internal code paths to bypass D-Bus authentication.

New Features:
- Require sender-based invoke permission verification for CleanArchives, CleanJob, PauseJob, and StartJob D-Bus methods.

Enhancements:
- Extract job cleanup logic into an internal cleanJob helper and use it for internal callers to avoid redundant D-Bus auth checks.