### PR TITLE
chore: update changelog to 6.2.63

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+lastore-daemon (6.2.63) unstable; urgency=medium
+
+  * fix(security): add caller verification for Updater sensitive methods
+  * i18n: Updates for project Deepin Desktop Environment (#454)
+  * fix(security): add caller verification for
+    CleanArchives/CleanJob/PauseJob/StartJob
+  * fix(manager): authorize rollback confirmation
+  * fix(updater): add authorization check to SetInstallUpdateTime method
+    (#451)
+
+ -- wangzhaohui <wangzhaohui@uniontech.com>  Tue, 21 Jul 2026 20:50:39 +0800
+
 lastore-daemon (6.2.62) unstable; urgency=medium
 
   * fix(dconfig): restore install-package-support-auth config entry


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.2.63

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.2.63
- 目标分支: master

## Summary by Sourcery

Build:
- Adjust Debian packaging changelog entry for version 6.2.63.