### PR TITLE
fix: add permission check for CheckUpgrade D-Bus method

### DIFF
--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -506,6 +506,9 @@ func (m *Manager) PrepareDistUpgradePartly(sender dbus.Sender, mode system.Updat
 
 func (m *Manager) CheckUpgrade(sender dbus.Sender, checkMode system.UpdateType, checkOrder uint32) (job dbus.ObjectPath, busErr *dbus.Error) {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return "", dbusutil.ToError(err)
+	}
 	job, err := m.checkUpgrade(sender, checkMode, checkType(checkOrder))
 	if err != nil {
 		logger.Warning(err)


### PR DESCRIPTION
Add checkInvokePermission call before processing CheckUpgrade requests.

在 CheckUpgrade 方法执行前添加调用权限校验。

Log: CheckUpgrade 增加调用权限校验
PMS: BUG-367863
Influence: 防止未授权调用方触发升级检查，提升 D-Bus 接口安全性。