### PR TITLE
fix(security): add caller verification for more Manager and Updater methods

### DIFF
--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -68,8 +68,11 @@ func (m *Manager) FixError(sender dbus.Sender, errType string) (job dbus.ObjectP
 	return jobObj.getPath(), nil
 }
 
-func (m *Manager) GetArchivesInfo() (info string, busErr *dbus.Error) {
+func (m *Manager) GetArchivesInfo(sender dbus.Sender) (info string, busErr *dbus.Error) {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return "", dbusutil.ToError(err)
+	}
 	info, err := getArchiveInfo()
 	if err != nil {
 		return "", dbusutil.ToError(err)
@@ -111,17 +114,26 @@ func (m *Manager) InstallPackageFromRepo(sender dbus.Sender, jobName string, sou
 	return jobObj.getPath(), nil
 }
 
-func (m *Manager) PackageExists(pkgId string) (exist bool, busErr *dbus.Error) {
+func (m *Manager) PackageExists(sender dbus.Sender, pkgId string) (exist bool, busErr *dbus.Error) {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return false, dbusutil.ToError(err)
+	}
 	return system.QueryPackageInstalled(pkgId), nil
 }
 
-func (m *Manager) PackageInstallable(pkgId string) (installable bool, busErr *dbus.Error) {
+func (m *Manager) PackageInstallable(sender dbus.Sender, pkgId string) (installable bool, busErr *dbus.Error) {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return false, dbusutil.ToError(err)
+	}
 	return system.QueryPackageInstallable(pkgId), nil
 }
 
-func (m *Manager) GetUpdateLogs(updateType system.UpdateType) (changeLogs string, busErr *dbus.Error) {
+func (m *Manager) GetUpdateLogs(sender dbus.Sender, updateType system.UpdateType) (changeLogs string, busErr *dbus.Error) {
+	if err := m.checkInvokePermission(sender); err != nil {
+		return "", dbusutil.ToError(err)
+	}
 	res := make(map[system.UpdateType]interface{})
 	if updateType&system.SystemUpdate != 0 {
 		res[system.SystemUpdate] = m.updatePlatform.SystemUpdateLogs
@@ -152,12 +164,18 @@ func (m *Manager) GetUpdateLogs(updateType system.UpdateType) (changeLogs string
 //	ChangelogZh []string
 // }
 
-func (m *Manager) GetHistoryLogs() (changeLogs string, busErr *dbus.Error) {
+func (m *Manager) GetHistoryLogs(sender dbus.Sender) (changeLogs string, busErr *dbus.Error) {
+	if err := m.checkInvokePermission(sender); err != nil {
+		return "", dbusutil.ToError(err)
+	}
 	return getHistoryChangelog(upgradeRecordPath), nil
 }
 
-func (m *Manager) PackagesSize(packages []string) (int64, *dbus.Error) {
+func (m *Manager) PackagesSize(sender dbus.Sender, packages []string) (int64, *dbus.Error) {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return 0, dbusutil.ToError(err)
+	}
 	m.ensureUpdateSourceOnce()
 	var err error
 	var allPackageSize float64
@@ -180,8 +198,11 @@ func (m *Manager) PackagesSize(packages []string) (int64, *dbus.Error) {
 	return int64(allPackageSize), dbusutil.ToError(err)
 }
 
-func (m *Manager) PackagesDownloadSize(packages []string) (int64, *dbus.Error) {
+func (m *Manager) PackagesDownloadSize(sender dbus.Sender, packages []string) (int64, *dbus.Error) {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return 0, dbusutil.ToError(err)
+	}
 	m.ensureUpdateSourceOnce()
 	var err error
 	var size float64
@@ -297,8 +318,11 @@ func (m *Manager) RemovePackage(sender dbus.Sender, jobName string, packages str
 	return jobObj.getPath(), nil
 }
 
-func (m *Manager) SetAutoClean(enable bool) *dbus.Error {
+func (m *Manager) SetAutoClean(sender dbus.Sender, enable bool) *dbus.Error {
 	m.service.DelayAutoQuit()
+	if err := m.checkInvokePermission(sender); err != nil {
+		return dbusutil.ToError(err)
+	}
 	if m.AutoClean == enable {
 		return nil
 	}
@@ -488,7 +512,10 @@ func (m *Manager) PrepareFullScreenUpgrade(sender dbus.Sender, option string) *d
 	return nil
 }
 
-func (m *Manager) QueryAllSizeWithSource(mode system.UpdateType) (int64, *dbus.Error) {
+func (m *Manager) QueryAllSizeWithSource(sender dbus.Sender, mode system.UpdateType) (int64, *dbus.Error) {
+	if err := m.checkInvokePermission(sender); err != nil {
+		return 0, dbusutil.ToError(err)
+	}
 	var sourcePathList []string
 	for _, t := range system.AllInstallUpdateType() {
 		category := mode & t
@@ -543,6 +570,9 @@ func (m *Manager) CheckUpgrade(sender dbus.Sender, checkMode system.UpdateType, 
 }
 
 func (m *Manager) PowerOff(sender dbus.Sender, reboot bool) *dbus.Error {
+	if err := m.checkInvokePermission(sender); err != nil {
+		return dbusutil.ToError(err)
+	}
 	args := []string{
 		"-f",
 	}
@@ -674,7 +704,10 @@ func (m *Manager) ConfirmRollback(sender dbus.Sender, confirm bool) *dbus.Error 
 	return nil
 }
 
-func (m *Manager) CanRollback() (bool, string, *dbus.Error) {
+func (m *Manager) CanRollback(sender dbus.Sender) (bool, string, *dbus.Error) {
+	if err := m.checkInvokePermission(sender); err != nil {
+		return false, "", dbusutil.ToError(err)
+	}
 	can, info := m.immutableManager.osTreeCanRollback()
 	return can, info, nil
 }

--- a/src/lastore-daemon/updater_ifc.go
+++ b/src/lastore-daemon/updater_ifc.go
@@ -15,8 +15,11 @@ import (
 	"github.com/linuxdeepin/lastore-daemon/src/internal/ratelimit"
 )
 
-func (u *Updater) GetCheckIntervalAndTime() (interval float64, checkTime string, busErr *dbus.Error) {
+func (u *Updater) GetCheckIntervalAndTime(sender dbus.Sender) (interval float64, checkTime string, busErr *dbus.Error) {
 	u.service.DelayAutoQuit()
+	if err := u.manager.checkInvokePermission(sender); err != nil {
+		return 0, "", dbusutil.ToError(err)
+	}
 	interval = u.config.CheckInterval.Hours()
 	checkTime = u.config.LastCheckTime.Format("2006-01-02 15:04:05.999999999 -0700 MST")
 	return
@@ -80,8 +83,11 @@ func (u *Updater) setAutoDownloadUpdates(enable bool) error {
 	return nil
 }
 
-func (u *Updater) ListMirrorSources(lang string) (mirrorSources []LocaleMirrorSource, busErr *dbus.Error) {
+func (u *Updater) ListMirrorSources(sender dbus.Sender, lang string) (mirrorSources []LocaleMirrorSource, busErr *dbus.Error) {
 	u.service.DelayAutoQuit()
+	if err := u.manager.checkInvokePermission(sender); err != nil {
+		return nil, dbusutil.ToError(err)
+	}
 	return u.listMirrorSources(lang), nil
 }
 
@@ -276,7 +282,10 @@ func (u *Updater) CleanTransmissionFiles(sender dbus.Sender) *dbus.Error {
 	return nil
 }
 
-func (u *Updater) SetDeliveryDownloadSpeedLimit(limitConfig string) *dbus.Error {
+func (u *Updater) SetDeliveryDownloadSpeedLimit(sender dbus.Sender, limitConfig string) *dbus.Error {
+	if err := u.manager.checkInvokePermission(sender); err != nil {
+		return dbusutil.ToError(err)
+	}
 	var speedLimitConfig speedLimitConfig
 	if err := json.Unmarshal([]byte(limitConfig), &speedLimitConfig); err != nil {
 		return dbusutil.ToError(err)
@@ -322,7 +331,10 @@ func (u *Updater) SetDeliveryDownloadSpeedLimit(limitConfig string) *dbus.Error 
 	return nil
 }
 
-func (u *Updater) SetDeliveryUploadSpeedLimit(limitConfig string) *dbus.Error {
+func (u *Updater) SetDeliveryUploadSpeedLimit(sender dbus.Sender, limitConfig string) *dbus.Error {
+	if err := u.manager.checkInvokePermission(sender); err != nil {
+		return dbusutil.ToError(err)
+	}
 	var speedLimitConfig speedLimitConfig
 	if err := json.Unmarshal([]byte(limitConfig), &speedLimitConfig); err != nil {
 		return dbusutil.ToError(err)


### PR DESCRIPTION
Add sender parameter and checkInvokePermission calls to the following D-Bus methods that were missing authorization checks:

Manager: GetArchivesInfo, PackageExists, PackageInstallable, GetUpdateLogs, GetHistoryLogs, PackagesSize, PackagesDownloadSize, RegisterAgent, SetAutoClean, UnRegisterAgent, QueryAllSizeWithSource, PowerOff, CanRollback

Updater: GetCheckIntervalAndTime, ListMirrorSources, SetDeliveryDownloadSpeedLimit, SetDeliveryUploadSpeedLimit

Bug: https://pms.uniontech.com/bug-view-371795.html

## Summary by Sourcery

Enforce caller authorization for additional Manager and Updater D-Bus methods to close missing security checks.

Bug Fixes:
- Add caller verification to Manager methods handling archive info, package queries, logs, size calculations, agent registration, auto-clean configuration, aggregate size queries, power operations, and rollback capability checks.
- Require caller authorization for Updater methods related to update check scheduling, mirror source listing, and delivery speed limit configuration.