### PR TITLE
fix(security): validate package names to prevent apt-get option injection

### DIFF
--- a/src/internal/system/apt/all_test.go
+++ b/src/internal/system/apt/all_test.go
@@ -25,3 +25,62 @@ func (*testWrap) TestParseInfo(c *C.C) {
 	c.Check(info.Status, C.Equals, system.RunningStatus)
 	c.Check(info.JobId, C.Equals, "jobid")
 }
+
+func (*testWrap) TestValidatePackageNames(c *C.C) {
+	// valid package names per dpkg pkg_name_is_illegal() strict rules
+	validCases := []string{
+		"vim",
+		"g++",
+		"libstdc++6",
+		"deepin-desktop-environment-core",
+		"qterminal-data",
+		"0ad",
+		"libfoo.bar.baz",
+		"libc6:amd64",
+		"libc6:AMD64",
+		"vim=2:8.1.2269-1+deb10u1",
+		"libc6=2.31-13+deb11u4~deb10u1",
+		"linux-image-amd64:amd64=5.10.0-1~bpo10+1",
+	}
+	for _, pkg := range validCases {
+		err := validatePackageNames([]string{pkg})
+		c.Check(err, C.IsNil, C.Commentf("expected %q to be valid", pkg))
+	}
+
+	// invalid package names that could be interpreted as apt-get options
+	// or violate dpkg naming policy
+	invalidCases := []string{
+		"--allow-unauthenticated",
+		"-y",
+		"--yes",
+		"-o",
+		"--option",
+		"--allow-downgrades",
+		"",
+		" ",
+		"-",
+		"--",
+		"pkg name", // contains space
+		"pkg$HOME", // contains shell metachar
+		"pkg;rm",   // contains shell metachar
+		"pkg\nmal", // contains newline
+		"PKG",      // uppercase not allowed by dpkg strict rules
+		"pkg_underscore",
+		".leadingdot",
+	}
+	for _, pkg := range invalidCases {
+		err := validatePackageNames([]string{pkg})
+		c.Check(err, C.NotNil, C.Commentf("expected %q to be invalid", pkg))
+	}
+
+	// empty slice is valid
+	c.Check(validatePackageNames(nil), C.IsNil)
+	c.Check(validatePackageNames([]string{}), C.IsNil)
+
+	// mixed valid and invalid
+	err := validatePackageNames([]string{"vim", "--allow-unauthenticated"})
+	c.Check(err, C.NotNil)
+
+	// multiple valid packages
+	c.Check(validatePackageNames([]string{"vim", "git", "curl"}), C.IsNil)
+}

--- a/src/internal/system/apt/proxy.go
+++ b/src/internal/system/apt/proxy.go
@@ -331,6 +331,34 @@ func safeStart(c *system.Command) error {
 	return nil
 }
 
+// pkgNameRegexp validates package name specifiers according to dpkg's
+// pkg_name_is_illegal() rules (lib/dpkg/parsehelp.c) and apt's package
+// specifier syntax.
+//
+// dpkg strict rules (scripts/Dpkg/Package.pm, deb-src-control.pod):
+//   - Must not be empty
+//   - First char: lowercase alphanumeric [a-z0-9]
+//   - Subsequent chars: [a-z0-9+.\-] (lowercase letters, digits, +, -, .)
+//
+// apt extensions (apt-pkg/cacheset.cc PackageFromPackageName):
+//   - ":arch" architecture suffix (arch chars: [a-zA-Z0-9-] per lib/dpkg/arch.c)
+//   - "=version" version selector (version chars: [a-zA-Z0-9.+~:*-])
+//
+// This prevents apt-get option injection: a package name starting with
+// '-' would be interpreted as an apt-get option rather than a package name.
+var pkgNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9+.\-]*(:[a-zA-Z0-9-]+)?(=[a-zA-Z0-9.+~:*-]+)?$`)
+
+// validatePackageNames ensures that all package names are valid apt
+// package specifiers and cannot be interpreted as apt-get options.
+func validatePackageNames(packages []string) error {
+	for _, pkg := range packages {
+		if !pkgNameRegexp.MatchString(pkg) {
+			return fmt.Errorf("invalid package name %q", pkg)
+		}
+	}
+	return nil
+}
+
 func OptionToArgs(options map[string]string) []string {
 	var args []string
 	for key, value := range options { // apt 命令执行参数
@@ -341,6 +369,9 @@ func OptionToArgs(options map[string]string) []string {
 }
 
 func (p *APTSystem) DownloadPackages(jobId string, packages []string, environ map[string]string, args map[string]string) error {
+	if err := validatePackageNames(packages); err != nil {
+		return err
+	}
 	err := CheckPkgSystemError(false, p.Indicator)
 	if err != nil {
 		return err
@@ -351,6 +382,9 @@ func (p *APTSystem) DownloadPackages(jobId string, packages []string, environ ma
 }
 
 func (p *APTSystem) DownloadSource(jobId string, packages []string, environ map[string]string, args map[string]string) error {
+	if err := validatePackageNames(packages); err != nil {
+		return err
+	}
 	// 无需检查依赖错误
 	/*
 		err := CheckPkgSystemError(false)
@@ -387,6 +421,9 @@ func (p *APTSystem) DownloadSource(jobId string, packages []string, environ map[
 }
 
 func (p *APTSystem) Remove(jobId string, packages []string, environ map[string]string) error {
+	if err := validatePackageNames(packages); err != nil {
+		return err
+	}
 	WaitDpkgLockRelease()
 	err := CheckPkgSystemError(true, p.Indicator)
 	if err != nil {
@@ -400,6 +437,9 @@ func (p *APTSystem) Remove(jobId string, packages []string, environ map[string]s
 }
 
 func (p *APTSystem) Install(jobId string, packages []string, environ map[string]string, args map[string]string) error {
+	if err := validatePackageNames(packages); err != nil {
+		return err
+	}
 	WaitDpkgLockRelease()
 	err := CheckPkgSystemError(true, p.Indicator)
 	if err != nil {
@@ -412,6 +452,9 @@ func (p *APTSystem) Install(jobId string, packages []string, environ map[string]
 }
 
 func (p *APTSystem) DistUpgrade(jobId string, packages []string, environ map[string]string, args map[string]string) error {
+	if err := validatePackageNames(packages); err != nil {
+		return err
+	}
 	WaitDpkgLockRelease()
 	err := CheckPkgSystemError(true, p.Indicator)
 	if err != nil {


### PR DESCRIPTION
Add validatePackageNames() with strict regex based on dpkg's pkg_name_is_illegal() rules and apt's :arch/=version specifier syntax, preventing apt-get option injection via user-controllable package names.

Bug: https://pms.uniontech.com/bug-view-371781.html, https://pms.uniontech.com/bug-view-371791.html

## Summary by Sourcery

Validate apt package names before executing package operations to prevent option injection via user-controlled package specifiers.

New Features:
- Introduce strict package name validation based on dpkg and apt syntax for all apt package operations.

Bug Fixes:
- Prevent apt-get option injection by rejecting package specifiers that could be interpreted as command-line options or violate dpkg naming rules.

Tests:
- Add unit tests covering valid and invalid package name specifiers, ensuring mixed and empty package lists are handled correctly.