### PR TITLE
fix(security): fix TOCTOU symlink race in PrepareFullScreenUpgrade

### DIFF
--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -22,7 +22,6 @@ import (
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/gettext"
 	"github.com/linuxdeepin/go-lib/procfs"
-	utils2 "github.com/linuxdeepin/go-lib/utils"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/system/apt"
@@ -397,7 +396,7 @@ func (m *Manager) PrepareFullScreenUpgrade(sender dbus.Sender, option string) *d
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
-	logger.Info("start PrepareFullScreenUpgrade")
+	logger.Infof("start PrepareFullScreenUpgrade with option: %s", option)
 
 	if supportOption {
 		opt := fullUpgradeOption{}
@@ -415,10 +414,30 @@ func (m *Manager) PrepareFullScreenUpgrade(sender dbus.Sender, option string) *d
 			logger.Warning(err)
 			return dbusutil.ToError(err)
 		}
-		if utils2.IsSymlink(optionFilePathTemp) {
-			_ = os.RemoveAll(optionFilePathTemp)
+		tmpFile, err := os.CreateTemp("/tmp", "deepin_update_option_*.json")
+		if err != nil {
+			logger.Warning(err)
+			return dbusutil.ToError(err)
 		}
-		_ = os.WriteFile(optionFilePathTemp, content, 0644)
+		tmpPath := tmpFile.Name()
+		if _, err := tmpFile.Write(content); err != nil {
+			_ = os.Remove(tmpPath)
+			tmpFile.Close()
+			logger.Warning(err)
+			return dbusutil.ToError(err)
+		}
+		tmpFile.Close()
+
+		if err := os.Chmod(tmpPath, 0644); err != nil {
+			_ = os.Remove(tmpPath)
+			logger.Warning(err)
+			return dbusutil.ToError(err)
+		}
+		if err := os.Rename(tmpPath, optionFilePathTemp); err != nil {
+			_ = os.Remove(tmpPath)
+			logger.Warning(err)
+			return dbusutil.ToError(err)
+		}
 	}
 
 	terminate := func() error {


### PR DESCRIPTION
Replace the non-atomic IsSymlink-check-then-write pattern with os.CreateTemp + os.Rename to eliminate the TOCTOU race window.

Previously, the code checked if /tmp/deepin_update_option.json was a symlink, removed it, then wrote the file. Between the remove and write, a local attacker could create a symlink to an arbitrary root-writable file, causing privilege escalation.

The fix uses os.CreateTemp with a random suffix (unpredictable path) to write content, then os.Rename to atomically replace the target. rename(2) does not follow symlinks, making the operation safe.

Bug: https://pms.uniontech.com/bug-view-371799.html

## Summary by Sourcery

Harden PrepareFullScreenUpgrade option file handling to eliminate a TOCTOU symlink race and improve logging of upgrade options.

Bug Fixes:
- Eliminate a symlink-based TOCTOU race when writing the full-screen upgrade option file by using a temporary file and atomic rename.

Enhancements:
- Include the selected upgrade option in the PrepareFullScreenUpgrade start log message for better observability.