### PR TITLE
fix(system): prevent false success report when backup command fails

### DIFF
--- a/src/internal/system/apt/proxy.go
+++ b/src/internal/system/apt/proxy.go
@@ -760,12 +760,20 @@ func parseBackupJobError(stdErrStr string, stdOutStr string) *system.JobError {
 		}
 	}
 	if output.Code == 0 {
-		// success
-		return nil
+		// 如果命令退出码为非0,理论上output.Code就不应该为0
+		logger.Warningf("command exit code is not 0, but output.Code is 0: code=%d, message=%s", output.Code, output.Message)
+		output.Code = 1
 	}
 
-	errDetail := fmt.Sprintf("err code: %v, err message: %+v",
-		output.Error.Code, output.Error.Message)
+	// output.Error 可能为 nil（JSON 中缺少 error 字段），需做防护
+	var errDetail string
+	if output.Error != nil {
+		errDetail = fmt.Sprintf("err code: %v, err message: %+v",
+			output.Error.Code, output.Error.Message)
+	} else {
+		errDetail = fmt.Sprintf("err code: %v, err message: %s",
+			output.Code, output.Message)
+	}
 
 	return &system.JobError{
 		ErrType:   system.ErrorUnknown,

--- a/src/internal/system/command.go
+++ b/src/internal/system/command.go
@@ -231,12 +231,12 @@ func (c *Command) atExit() {
 			Cancelable: false,
 		})
 	case ExitFailure:
-		c.Indicator(JobProgressInfo{
-			OnlyLog:     true,
-			OriginalLog: c.Stderr.String(),
-		})
-		err := c.ParseJobError(c.Stderr.String(), c.Stdout.String())
-		if err != nil {
+		// 正常情况ParseJobError应该会返回一个非nil的JobError
+		if err := c.ParseJobError(c.Stderr.String(), c.Stdout.String()); err != nil {
+			c.Indicator(JobProgressInfo{
+				OnlyLog:     true,
+				OriginalLog: err.GetDetail(),
+			})
 			c.Indicator(JobProgressInfo{
 				JobId:      c.JobId,
 				Status:     FailedStatus,
@@ -245,6 +245,7 @@ func (c *Command) atExit() {
 				Error:      err,
 			})
 		} else {
+			// 理论上不应该走到这个流程上面来
 			c.Indicator(JobProgressInfo{
 				JobId:      c.JobId,
 				Status:     SucceedStatus,


### PR DESCRIPTION
- parseBackupJobError: force output.Code=1 when command fails but JSON code is 0
- parseBackupJobError: add nil check for output.Error to prevent panic
- atExit: only report OriginalLog when ParseJobError returns non-nil error

## Summary by Sourcery

Ensure backup command failures are correctly surfaced as job errors instead of false successes.

Bug Fixes:
- Treat mismatches between command exit code and parsed JSON code as failures and log a warning.
- Prevent nil pointer panics when backup job JSON output omits the error field.
- Report detailed parsed job errors in failure indicators instead of raw stderr, avoiding success status on failures.