### PR TITLE
fix(upgrade): fail jobs when immutable refresh fails

### DIFF
--- a/src/internal/system/common.go
+++ b/src/internal/system/common.go
@@ -137,6 +137,7 @@ const (
 	ErrorDamagePackage           JobErrorType = "damagePackage" // 包损坏,需要删除后重新下载或者安装
 	ErrorInvalidSourcesList      JobErrorType = "invalidSourceList"
 	ErrorPlatformUnreachable     JobErrorType = "platformUnreachable"
+	ErrorImmutableRefreshFailed  JobErrorType = "immutableRefreshFailed"
 
 	ErrorMissCoreFile  JobErrorType = "missCoreFile"
 	ErrorScript        JobErrorType = "scriptError"

--- a/src/lastore-daemon/manager_upgrade.go
+++ b/src/lastore-daemon/manager_upgrade.go
@@ -569,8 +569,7 @@ func (m *Manager) distUpgrade(sender dbus.Sender, mode system.UpdateType,
 				if mode&system.SecurityUpdate != 0 {
 					recordUpgradeLog(uuid, system.SecurityUpdate, m.updatePlatform.GetCVEUpdateLogs(m.updater.getUpdatablePackagesByType(system.SecurityUpdate)), upgradeRecordPath)
 				}
-				_ = m.preUpgradeCmdSuccessHook(job, mode, uuid, refreshFullMerge)
-				return nil
+				return m.preUpgradeCmdSuccessHook(job, mode, uuid, refreshFullMerge)
 			},
 			string(system.FailedStatus): func() error {
 				_ = m.preFailedHook(job, mode, uuid)
@@ -814,7 +813,11 @@ func (m *Manager) preUpgradeCmdSuccessHook(job *Job, mode system.UpdateType, uui
 	// Perform immutable system refresh at the end of the upgrade process
 	if m.statusManager.abStatus == system.HasBackedUp {
 		if err := m.immutableManager.osTreeRefresh(refreshFullMerge); err != nil {
-			logger.Warning("ostree deploy refresh failed,", err)
+			logger.Warning("immutable-ctl admin deploy refresh failed:", err)
+			return &system.JobError{
+				ErrType:   system.ErrorImmutableRefreshFailed,
+				ErrDetail: err.Error(),
+			}
 		}
 	}
 


### PR DESCRIPTION
Propagate the immutable deployment refresh error through the success hook so the
upgrade job enters its established failure flow rather than reporting success.

PMS: TASK-393767

## Summary by Sourcery

Ensure upgrade jobs fail when immutable system refresh fails during the pre-upgrade success hook.

Bug Fixes:
- Propagate immutable system refresh errors from the pre-upgrade success hook so upgrade jobs follow the failure path instead of reporting success.

Enhancements:
- Introduce a specific JobErrorType for immutable refresh failures to classify and report these errors more accurately.