### PR TITLE
fix(security): scope D-Bus deny rules to Manager interface

### DIFF
--- a/usr/share/dbus-1/system.d/org.deepin.dde.Lastore1.conf
+++ b/usr/share/dbus-1/system.d/org.deepin.dde.Lastore1.conf
@@ -17,10 +17,10 @@
     <allow send_destination="org.deepin.dde.Lastore1"/>
     <allow receive_sender="org.deepin.dde.Lastore1"/>
     <deny send_destination="org.deepin.dde.Lastore1"
-          send_interface="org.deepin.dde.Lastore1"
+          send_interface="org.deepin.dde.Lastore1.Manager"
           send_member="SetAllowCaller"/>
     <deny send_destination="org.deepin.dde.Lastore1"
-          send_interface="org.deepin.dde.Lastore1"
+          send_interface="org.deepin.dde.Lastore1.Manager"
           send_member="PowerOff"/>
   </policy>
   <policy group="deepin-daemon">


### PR DESCRIPTION
The deny rules for SetAllowCaller and PowerOff were matching the generic org.deepin.dde.Lastore1 interface, which is shared across multiple objects. Narrow them to org.deepin.dde.Lastore1.Manager so the restrictions target the correct object and cannot be bypassed by routing sensitive calls through a different exposed interface.

PMS: BUG-372909

## Summary by Sourcery

Bug Fixes:
- Correct the D-Bus configuration so SetAllowCaller and PowerOff deny rules target the org.deepin.dde.Lastore1.Manager interface instead of the generic org.deepin.dde.Lastore1 interface.