### PR TITLE
chore: update changelog to 6.2.65

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+lastore-daemon (6.2.65) unstable; urgency=medium
+
+  * fix(security): unify polkit auth via checkInvokePermission and drop
+    orphaned actions
+  * Revert "refactor(updateplatform): always use update platform logs"
+    (#465)
+  * fix(security): scope D-Bus deny rules to Manager interface (#464)
+  * fix(upgrade): fail jobs when immutable refresh fails
+  * fix(security): add caller verification for more Manager and Updater
+    methods
+  * refactor(updateplatform): always use update platform logs
+  * fix(system): prevent false success report when backup command fails
+
+ -- wangzhaohui <wangzhaohui@uniontech.com>  Fri, 07 Aug 2026 13:06:11 +0800
+
 lastore-daemon (6.2.64) unstable; urgency=medium
 
   * fix(security): fix TOCTOU symlink race in PrepareFullScreenUpgrade


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.2.65

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.2.65
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog entry to reflect release 6.2.65.