### PR TITLE
fix: disable immutable remount for read-only dpkg/apt queries

### DIFF
--- a/src/internal/system/system_apt.go
+++ b/src/internal/system/system_apt.go
@@ -365,7 +365,6 @@ func init() {
 	_ = os.Setenv("DEBIAN_FRONTEND", "noninteractive")
 	_ = os.Setenv("DEBIAN_PRIORITY", "critical")
 	_ = os.Setenv("DEBCONF_NONINTERACTIVE_SEEN", "true")
-	_ = os.Setenv("IMMUTABLE_DISABLE_REMOUNT", "true")
 }
 
 func guestBasePackageName(pkgId string) string {

--- a/src/lastore-apt-clean/main.go
+++ b/src/lastore-apt-clean/main.go
@@ -68,6 +68,9 @@ func findBins() {
 var _archivesDirInfos []*archivesDirInfo
 
 func main() {
+	// 默认禁用不可变系统的 remount，仅对需要写 /usr 的子进程显式置为 false
+	_ = os.Setenv("IMMUTABLE_DISABLE_REMOUNT", "true")
+
 	flag.Parse()
 	if options.printJSON {
 		// 让 logger 不在标准输出打印其他内容，只打印在系统日志中。

--- a/src/lastore-daemon/main.go
+++ b/src/lastore-daemon/main.go
@@ -45,6 +45,7 @@ var logger = log.NewLogger("lastore/lastore-daemon")
 //go:generate dbusutil-gen em -type Manager,Updater
 
 func main() {
+	_ = os.Setenv("IMMUTABLE_DISABLE_REMOUNT", "true")
 	flag.Parse()
 	service, err := dbusutil.NewSystemService()
 	if err != nil {

--- a/src/lastore-tools/main.go
+++ b/src/lastore-tools/main.go
@@ -92,6 +92,9 @@ func MainUpdater(c *cli.Context) (err error) {
 }
 
 func main() {
+	// 默认禁用不可变系统的 remount，仅对需要写 /usr 的子进程显式置为 false
+	_ = os.Setenv("IMMUTABLE_DISABLE_REMOUNT", "true")
+
 	// 清除语言相关环境变量
 	_ = utils.UnsetEnv("LC_ALL")
 	_ = utils.UnsetEnv("LANGUAGE")

--- a/src/lastore-tools/upgradable.go
+++ b/src/lastore-tools/upgradable.go
@@ -110,7 +110,6 @@ func queryDpkgUpgradeInfoByAptList(sourcePath string) ([]string, error) {
 	}
 	args = append(args, []string{"list", "--upgradable"}...)
 	cmd := exec.Command("apt", append(args, ps...)...) // #nosec G204
-	cmd.Env = append(os.Environ(), "IMMUTABLE_DISABLE_REMOUNT=true")
 	r, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -145,7 +144,6 @@ func queryDpkgUpgradeInfoByAptList(sourcePath string) ([]string, error) {
 
 func getSystemArchitectures() []system.Architecture {
 	cmd := exec.Command("dpkg", "--print-foreign-architectures")
-	cmd.Env = append(os.Environ(), "IMMUTABLE_DISABLE_REMOUNT=true")
 	foreignArchs, err := cmd.Output()
 	if err != nil {
 		logger.Warningf("GetSystemArchitecture failed:%v\n", foreignArchs)

--- a/src/lastore-update-tools/config/cache/package.go
+++ b/src/lastore-update-tools/config/cache/package.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os/exec"
 	"path"
 	"reflect"
 	"regexp"
@@ -48,7 +47,6 @@ var (
 		// "SHA512",
 		// "Description",
 	}
-	sysRealArch string
 )
 
 var softwareFieldMap map[string]int
@@ -70,15 +68,6 @@ func init() {
 				softwareFieldMap[names[name]] = i
 			}
 		}
-	}
-
-	cmd := exec.Command("/usr/bin/dpkg", "--print-architecture")
-
-	var output bytes.Buffer
-	cmd.Stdout = &output
-	err := cmd.Run()
-	if err == nil {
-		sysRealArch = strings.TrimSpace(output.String())
 	}
 }
 

--- a/src/lastore-update-tools/controller/check/check.go
+++ b/src/lastore-update-tools/controller/check/check.go
@@ -1,9 +1,7 @@
 package check
 
 import (
-	"bytes"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -30,19 +28,6 @@ func SetDynHookTimeout(seconds int) {
 }
 
 var logger = log.NewLogger("lastore/update-tools/check")
-
-var sysRealArch string
-
-func init() {
-	cmd := exec.Command("/usr/bin/dpkg", "--print-architecture")
-
-	var output bytes.Buffer
-	cmd.Stdout = &output
-	err := cmd.Run()
-	if err == nil {
-		sysRealArch = strings.TrimSpace(output.String())
-	}
-}
 
 // DONE(heysion): 修改错误返回
 func LoadSysPkgInfo(pkgs map[string]*cache.AppTinyInfo) error {


### PR DESCRIPTION
For read-only or verification commands such as 'dpkg --print-architecture', 'dpkg --print-foreign-architectures' and 'apt list --upgradable', no data is written to the system, so remounting the immutable /usr to rw is unnecessary. Set IMMUTABLE_DISABLE_REMOUNT=true on these subprocesses to skip the redundant remount flow.

Note: most other dpkg/apt query call sites inherit this variable via the process-level os.Setenv in src/internal/system/system_apt.go init(). config/cache is the exception because it does not import the system package, so an explicit Env assignment there is required.

## Summary by Sourcery

Disable immutable /usr remounts for read-only dpkg and apt query commands by marking these subprocesses as remount-safe.

Enhancements:
- Ensure dpkg architecture and foreign-architecture queries run with IMMUTABLE_DISABLE_REMOUNT set to avoid unnecessary remounts.
- Propagate IMMUTABLE_DISABLE_REMOUNT to apt source download size queries and lastore tools that invoke dpkg for architecture detection.