### PR TITLE
fix: open update page via dbus in notifications

### DIFF
--- a/src/lastore-daemon/manager.go
+++ b/src/lastore-daemon/manager.go
@@ -984,6 +984,10 @@ func (m *Manager) handleUserRemoved(uid uint32, userPath dbus.ObjectPath) {
 const (
 	updateNotifyShow         = "dde-control-center"          // 无论控制中心状态，都需要发送的通知
 	updateNotifyShowOptional = "dde-control-center-optional" // 根据控制中心更新模块焦点状态,选择性的发通知(由dde-session-daemon的lastore agent判断后控制)
+
+	// 通知中"查看/重试/立即更新"按钮的动作: 通过 DBus 调用控制中心打开更新页面
+	// Notification action for View/Retry/UpdateNow: open the update page via DBus
+	actionShowUpdateModule = "dbus-send,--session,--print-reply,--dest=org.deepin.dde.ControlCenter1,/org/deepin/dde/ControlCenter1,org.deepin.dde.ControlCenter1.ShowModule,string:update"
 )
 
 func (m *Manager) sendNotify(appName string, replacesId uint32, appIcon string, summary string, body string, actions []string, hints map[string]dbus.Variant, expireTimeout int32) uint32 {

--- a/src/lastore-daemon/manager_download.go
+++ b/src/lastore-daemon/manager_download.go
@@ -280,7 +280,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 					if m.config.IntranetUpdate {
 						go m.sendNotify(updateNotifyShow, 0, "preferences-system", "", msg, nil, nil, system.NotifyExpireTimeoutPrivate)
 					} else {
-						hints := map[string]dbus.Variant{"x-deepin-action-view": dbus.MakeVariant("dde-control-center,-m,update")}
+						hints := map[string]dbus.Variant{"x-deepin-action-view": dbus.MakeVariant(actionShowUpdateModule)}
 						go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, action, hints, system.NotifyExpireTimeoutDefault)
 					}
 				})
@@ -347,12 +347,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 						cleanAllCache()
 						msg := gettext.Tr("Updates failed: damaged files. Please update again.")
 						action := []string{"retry", gettext.Tr("Try Again")}
-						var hints map[string]dbus.Variant
-						if m.config.IntranetUpdate {
-							hints = map[string]dbus.Variant{"x-deepin-action-retry": dbus.MakeVariant("dde-control-center,-m,updateprivate")}
-						} else {
-							hints = map[string]dbus.Variant{"x-deepin-action-retry": dbus.MakeVariant("dde-control-center,-m,update")}
-						}
+						hints := map[string]dbus.Variant{"x-deepin-action-retry": dbus.MakeVariant(actionShowUpdateModule)}
 						go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, action, hints, system.NotifyExpireTimeoutDefault)
 					} else if strings.Contains(errorContent.ErrType.String(), system.ErrorFetchFailed.String()) {
 						// 网络原因下载更新失败
@@ -440,7 +435,7 @@ func (m *Manager) prepareDistUpgrade(sender dbus.Sender, origin system.UpdateTyp
 									m.sendNotify(updateNotifyShow, 0, "preferences-system", "", msg, nil, nil, system.NotifyExpireTimeoutPrivate)
 								}
 							} else {
-								hints := map[string]dbus.Variant{"x-deepin-action-updateNow": dbus.MakeVariant("dde-control-center,-m,update")}
+								hints := map[string]dbus.Variant{"x-deepin-action-updateNow": dbus.MakeVariant(actionShowUpdateModule)}
 
 								m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, action, hints, system.NotifyExpireTimeoutDefault)
 							}

--- a/src/lastore-daemon/manager_update.go
+++ b/src/lastore-daemon/manager_update.go
@@ -244,13 +244,13 @@ func (m *Manager) updateSource(sender dbus.Sender) (*Job, error) {
 						action := []string{"view", gettext.Tr("View")}
 						var hints map[string]dbus.Variant
 						if m.config.IntranetUpdate {
-							hints = map[string]dbus.Variant{"x-deepin-action-view": dbus.MakeVariant("dde-control-center,-m,updateprivate")}
+							hints = map[string]dbus.Variant{"x-deepin-action-view": dbus.MakeVariant(actionShowUpdateModule)}
 							if m.updatePlatform.Tp == updateplatform.NormalUpdate {
 								msg = gettext.Tr("New version available! Please go to control-center to check")
 								go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, action, hints, system.NotifyExpireTimeoutPrivate)
 							}
 						} else {
-							hints = map[string]dbus.Variant{"x-deepin-action-view": dbus.MakeVariant("dde-control-center,-m,update")}
+							hints = map[string]dbus.Variant{"x-deepin-action-view": dbus.MakeVariant(actionShowUpdateModule)}
 							go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, action, hints, system.NotifyExpireTimeoutDefault)
 						}
 					}

--- a/src/lastore-daemon/manager_upgrade.go
+++ b/src/lastore-daemon/manager_upgrade.go
@@ -708,7 +708,7 @@ func (m *Manager) preFailedHook(job *Job, mode system.UpdateType, uuid string) e
 			if m.config.IntranetUpdate {
 				go m.sendNotify(updateNotifyShow, 0, "preferences-system", "", msg, nil, nil, system.NotifyExpireTimeoutPrivateLong)
 			} else {
-				hints := map[string]dbus.Variant{"x-deepin-action-retry": dbus.MakeVariant("dde-control-center,-m,update")}
+				hints := map[string]dbus.Variant{"x-deepin-action-retry": dbus.MakeVariant(actionShowUpdateModule)}
 				go m.sendNotify(updateNotifyShowOptional, 0, "preferences-system", "", msg, action, hints, system.NotifyExpireTimeoutDefault)
 			}
 		} else if strings.Contains(errType, system.ErrorInsufficientSpace.String()) {


### PR DESCRIPTION
1. Replace command-line action "dde-control-center,-m,update" in update notification hints with a DBus call to org.deepin.dde.ControlCenter1.ShowModule string:"update"
2. Apply the change to all 5 notification action hints that target the update module (action-view, action-retry, action-updateNow) across manager_update.go, manager_download.go and manager_upgrade.go
3. Follows the existing dbus-send hint pattern already used in the codebase (e.g. ShutdownFront1.Restart, Lastore1.Manager.StartJob)

Log: Clicking the View button on the updates-available notification now opens the control center update page via DBus instead of launching the command, fixing the case where the page failed to appear.

Influence:
1. Trigger a check-for-updates with available updates, close the control center, then click View on the notification - the update page should open
2. Verify the retry and updateNow notification actions also open the update page correctly
3. Confirm intranet-update (updateprivate) and network-error notifications are unaffected

fix: 通知查看按钮改为通过DBus打开更新界面

1. 将更新通知中的命令行动作 "dde-control-center,-m,update" 替换为 DBus 调用 org.deepin.dde.ControlCenter1.ShowModule string:"update"
2. 涉及更新模块的全部 5 处通知动作提示(action-view、action-retry、 action-updateNow),分布在 manager_update.go、manager_download.go 和 manager_upgrade.go
3. 与代码库中已有的 dbus-send 通知动作写法保持一致(如 ShutdownFront1.Restart、Lastore1.Manager.StartJob)

Log: 点击"检测到更新"通知的查看按钮时,改为通过 DBus 打开控制中心
更新界面,修复了之前点击后界面无法出现的问题

Influence:
1. 在有待更新包时触发检查更新,关闭控制中心后点击通知的查看按钮, 应能正常打开更新页面
2. 验证重试和立即更新通知动作也能正确打开更新页面
3. 确认内网更新(updateprivate)和网络错误通知不受影响

PMS: BUG-366983

## Summary by Sourcery

Use DBus to open the control center update page from update-related notification actions instead of invoking the dde-control-center command.

Bug Fixes:
- Ensure the View, Retry, and Update Now actions in update notifications reliably open the control center update module via DBus, fixing cases where the update page failed to appear.

Enhancements:
- Align update notification action hints with the existing DBus-based pattern used elsewhere in the daemon for control center interactions.