### PR TITLE
chore: update changelog to 6.2.66

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+lastore-daemon (6.2.66) unstable; urgency=medium
+
+  * fix: open update page via dbus in notifications (#471)
+  * i18n: Updates for project Deepin Desktop Environment (#468)
+  * fix: disable immutable remount for read-only dpkg/apt queries
+  * refactor(updateplatform): always use platform update logs with
+    default fallback
+
+ -- wangzhaohui <wangzhaohui@uniontech.com>  Fri, 14 Aug 2026 14:43:05 +0800
+
 lastore-daemon (6.2.65) unstable; urgency=medium
 
   * fix(security): unify polkit auth via checkInvokePermission and drop


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.2.66

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.2.66
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog to reflect new version 6.2.66 on master.