### PR TITLE
feat: add MajorUpgrade field to deepin_update_option.json for major version upgrade detection

### DIFF
--- a/src/internal/updateplatform/message_report.go
+++ b/src/internal/updateplatform/message_report.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -342,6 +343,44 @@ func getTargetSystemType() string {
 
 func getTargetVersion() string {
 	return getGeneralValueFromKeyFile(cacheBaseline, "Version")
+}
+
+// IsMajorUpgrade 判断当前更新是否为大版本升级。
+// 取本地 MinorVersion 与目标 targetVersion 交由 isMajorUpgrade 统一比较，
+// 仅当目标首段数值大于本地首段数值时才视为大版本升级，相等或小于均不算。
+// 版本号格式由各发行版约定：专业版为纯数字(如 2500)，社区版为点分(如 25.2.1)，
+// 取首段后均可正确比较(2500->2510、25.2.1->26.1.0)。
+func (m *UpdatePlatformManager) IsMajorUpgrade() bool {
+	if m.targetVersion == "" {
+		return false
+	}
+
+	infoMap, err := GetOSVersionInfo(CacheVersion)
+	if err != nil {
+		logger.Warningf("IsMajorUpgrade: failed to get os version info: %v", err)
+		return false
+	}
+
+	return isMajorUpgrade(infoMap["MinorVersion"], m.targetVersion)
+}
+
+// isMajorUpgrade 判断两个版本号之间是否发生大版本跃迁。
+// 对 oldVersion 和 newVersion 均按 "." 分段并取第一段，转换为数字后比较大小，
+// 仅当 newVersion 对应数值大于 oldVersion 时返回 true。
+// 对于不含 "." 的版本号(如专业版 "2500")，SplitN 会直接返回原字符串，转换不受影响。
+func isMajorUpgrade(oldVersion, newVersion string) bool {
+	oldStr := strings.SplitN(oldVersion, ".", 2)[0]
+	newStr := strings.SplitN(newVersion, ".", 2)[0]
+
+	oldVal, err1 := strconv.Atoi(oldStr)
+	newVal, err2 := strconv.Atoi(newStr)
+	if err1 != nil || err2 != nil {
+		logger.Warningf("isMajorUpgrade: parse version failed, old %q new %q", oldStr, newStr)
+		return false
+	}
+
+	logger.Debugf("isMajorUpgrade: old %d, new %d", oldVal, newVal)
+	return newVal > oldVal
 }
 
 func getGeneralValueFromKeyFile(path, key string) string {

--- a/src/internal/updateplatform/message_report_test.go
+++ b/src/internal/updateplatform/message_report_test.go
@@ -406,3 +406,35 @@ func TestGetCVEUpdateLogsStringEncodedJSON(t *testing.T) {
 		t.Fatal("expected CVE-2024-7006 in results")
 	}
 }
+
+func TestIsMajorUpgrade(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldVersion string
+		newVersion string
+		want       bool
+	}{
+		// 专业版：MinorVersion 为纯数字
+		{"professional: 2500 -> 2510 major", "2500", "2510", true},
+		{"professional: 2510 -> 2500 not major", "2510", "2500", false},
+		{"professional: 2500 -> 2500 equal", "2500", "2500", false},
+		// 社区版：MinorVersion 以 "." 分段，取第一段
+		{"community: 25.2.1 -> 26.1.0 major", "25.2.1", "26.1.0", true},
+		{"community: 26.1.0 -> 25.2.1 not major", "26.1.0", "25.2.1", false},
+		{"community: 25.2.1 -> 25.3.0 not major", "25.2.1", "25.3.0", false},
+		{"community: 25.2.1 -> 25.2.1 equal", "25.2.1", "25.2.1", false},
+		// 边界与异常
+		{"empty new version", "2500", "", false},
+		{"invalid old version", "abc", "2500", false},
+		{"invalid new version", "2500", "xyz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMajorUpgrade(tt.oldVersion, tt.newVersion)
+			if got != tt.want {
+				t.Fatalf("isMajorUpgrade(%q, %q) = %v, want %v", tt.oldVersion, tt.newVersion, got, tt.want)
+			}
+		})
+	}
+}

--- a/src/lastore-daemon/manager_check.go
+++ b/src/lastore-daemon/manager_check.go
@@ -184,6 +184,7 @@ type fullUpgradeOption struct {
 	PreGreeterCheck   bool
 	AfterGreeterCheck bool
 	UUID              string
+	MajorUpgrade      bool // 是否为大版本升级
 }
 
 const (
@@ -199,6 +200,7 @@ func (m *Manager) setRebootCheckOption(mode system.UpdateType, uuid string) erro
 		PreGreeterCheck:   true,
 		AfterGreeterCheck: true,
 		UUID:              uuid,
+		MajorUpgrade:      m.updatePlatform.IsMajorUpgrade(),
 	}
 	content, err := json.Marshal(option)
 	if err != nil {

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -437,6 +437,7 @@ func (m *Manager) PrepareFullScreenUpgrade(sender dbus.Sender, option string) *d
 		opt.DoUpgrade = true
 		opt.PreGreeterCheck = false
 		opt.AfterGreeterCheck = false
+		opt.MajorUpgrade = m.updatePlatform.IsMajorUpgrade()
 		content, err := json.Marshal(opt)
 		if err != nil {
 			logger.Warning(err)


### PR DESCRIPTION
Add a MajorUpgrade bool field to fullUpgradeOption so the frontend can determine whether the current update is a major version upgrade.

- Add UpdatePlatformManager.IsMajorUpgrade() comparing local MinorVersion with targetVersion via the generic isMajorUpgrade helper, which splits both old and new versions on '.' and compares the first numeric segment, so both pure-number (professional, e.g. 2500->2510) and dotted (community, e.g. 25.2.1->26.1.0) formats are handled uniformly; only target > current counts as a major upgrade.
- Extract generic isMajorUpgrade(oldVersion, newVersion) helper with tests.
- Populate MajorUpgrade in setRebootCheckOption (/etc/deepin) and PrepareFullScreenUpgrade (/tmp) for the frontend to read.
- Use Warningf for error logs and downgrade the success-path log to Debugf.

PMS: TASK-394209

## Summary by Sourcery

Expose major version upgrade status in update options and determine it from the leading component of local and target versions.

New Features:
- Expose whether an update is a major version upgrade in the generated full upgrade options for frontend consumers.

Enhancements:
- Support major-upgrade detection consistently for numeric and dotted version formats, treating only increases in the leading version component as major upgrades.

Tests:
- Add coverage for major-upgrade detection across upgrades, downgrades, equal versions, malformed versions, and both supported version formats.