### PR TITLE
fix(updater): skip redundant delivery speed limit settings when state unchanged

### DIFF
--- a/src/internal/ratelimit/ratelimit.go
+++ b/src/internal/ratelimit/ratelimit.go
@@ -56,6 +56,27 @@ type RateInfo struct {
 	CurrentRate int64     // 当前限制速率(实际限速速率：限速时，两者一致，不限速时，CurrentRate为最大限速速率)  unit: bytes per second
 }
 
+// SameAsConfig 判断当前限速状态与已存储的配置字符串是否一致，若一致则无需重复设置。
+// 对于不限速(RateLimitTypeNo)状态，仅比较 LimitType；
+// 对于本地限速(RateLimitTypeLocal)状态，需同时比较 LimitType 与 LimitRate。
+// 配置字符串为空或解析失败时视为不一致。
+func (r RateInfo) SameAsConfig(configStr string) bool {
+	if configStr == "" {
+		return false
+	}
+	var current RateInfo
+	if err := json.Unmarshal([]byte(configStr), &current); err != nil {
+		return false
+	}
+	switch r.LimitType {
+	case RateLimitTypeNo:
+		return current.LimitType == RateLimitTypeNo
+	case RateLimitTypeLocal:
+		return current.LimitType == RateLimitTypeLocal && current.LimitRate == r.LimitRate
+	}
+	return false
+}
+
 type RateInfoEvent struct {
 	RateInfo       // 生效速率信息
 	RateType int   // 类型(gloabl、busy、free)

--- a/src/internal/ratelimit/ratelimit_test.go
+++ b/src/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ratelimit
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRateInfoSameAsConfig(t *testing.T) {
+	noLimit := RateInfo{
+		LimitType:   RateLimitTypeNo,
+		LimitRate:   DefaultRateLimit,
+		CurrentRate: DefaultRateLimit,
+	}
+	localLimit := func(rate int64) RateInfo {
+		return RateInfo{
+			LimitType:   RateLimitTypeLocal,
+			LimitRate:   rate,
+			CurrentRate: rate,
+		}
+	}
+	remoteLimit := RateInfo{
+		LimitType:   RateLimitTypeRemote,
+		LimitRate:   2048 * 1024,
+		CurrentRate: 2048 * 1024,
+	}
+	noLimitPreservedRate := RateInfo{
+		LimitType:   RateLimitTypeNo,
+		LimitRate:   2048 * 1024,
+		CurrentRate: 2048 * 1024,
+	}
+
+	tests := []struct {
+		name      string
+		configStr string
+		rateInfo  RateInfo
+		want      bool
+	}{
+		{
+			name:      "empty config is never same",
+			configStr: "",
+			rateInfo:  noLimit,
+			want:      false,
+		},
+		{
+			name:      "invalid config is never same",
+			configStr: "not-json",
+			rateInfo:  noLimit,
+			want:      false,
+		},
+		{
+			name:      "no limit matches no limit ignoring rate",
+			configStr: marshalRateInfo(t, noLimitPreservedRate),
+			rateInfo:  noLimit,
+			want:      true,
+		},
+		{
+			name:      "no limit does not match local limit",
+			configStr: marshalRateInfo(t, localLimit(2048*1024)),
+			rateInfo:  noLimit,
+			want:      false,
+		},
+		{
+			name:      "local limit matches same rate",
+			configStr: marshalRateInfo(t, localLimit(2048*1024)),
+			rateInfo:  localLimit(2048 * 1024),
+			want:      true,
+		},
+		{
+			name:      "local limit does not match different rate",
+			configStr: marshalRateInfo(t, localLimit(2048*1024)),
+			rateInfo:  localLimit(4096 * 1024),
+			want:      false,
+		},
+		{
+			name:      "local limit does not match no limit",
+			configStr: marshalRateInfo(t, noLimit),
+			rateInfo:  localLimit(2048 * 1024),
+			want:      false,
+		},
+		{
+			name:      "unsupported rate limit type is never same",
+			configStr: marshalRateInfo(t, remoteLimit),
+			rateInfo:  remoteLimit,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rateInfo.SameAsConfig(tt.configStr); got != tt.want {
+				t.Fatalf("SameAsConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func marshalRateInfo(t *testing.T, info RateInfo) string {
+	t.Helper()
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("failed to marshal rate info: %v", err)
+	}
+	return string(data)
+}

--- a/src/lastore-daemon/updater_ifc.go
+++ b/src/lastore-daemon/updater_ifc.go
@@ -297,17 +297,15 @@ func (u *Updater) SetDeliveryDownloadSpeedLimit(sender dbus.Sender, limitConfig 
 	}
 
 	var rateInfo ratelimit.RateInfo
+	var rateLimit int
 	if speedLimitConfig.SpeedLimitEnabled {
 		limitRate, err := strconv.ParseInt(speedLimitConfig.LimitSpeed, 10, 64)
 		if err != nil {
 			return dbusutil.ToError(err)
 		}
-		rateLimit := int(limitRate)
+		rateLimit = int(limitRate)
 		if rateLimit*1024 < ratelimit.MinRateLimit || rateLimit*1024 > ratelimit.MaxRateLimit {
 			rateLimit = int(ratelimit.DefaultRateLimit) / 1024
-		}
-		if err := ratelimit.SetIPFSDownloadRateLimit(rateLimit); err != nil {
-			return dbusutil.ToError(err)
 		}
 		rateInfo = ratelimit.RateInfo{
 			LimitType:   ratelimit.RateLimitTypeLocal,
@@ -315,14 +313,21 @@ func (u *Updater) SetDeliveryDownloadSpeedLimit(sender dbus.Sender, limitConfig 
 			CurrentRate: int64(rateLimit) * 1024,
 		}
 	} else {
-		if err := ratelimit.SetIPFSDownloadRateLimit(-1); err != nil {
-			return dbusutil.ToError(err)
-		}
+		rateLimit = -1
 		rateInfo = ratelimit.RateInfo{
 			LimitType:   ratelimit.RateLimitTypeNo,
 			LimitRate:   ratelimit.DefaultRateLimit,
 			CurrentRate: ratelimit.DefaultRateLimit,
 		}
+	}
+
+	// 如果下发的状态与当前状态一致，则不需要重复设置
+	if rateInfo.SameAsConfig(u.config.DeliveryLocalDownloadGlobalLimit) {
+		return nil
+	}
+
+	if err := ratelimit.SetIPFSDownloadRateLimit(rateLimit); err != nil {
+		return dbusutil.ToError(err)
 	}
 
 	rateInfoData, err := json.Marshal(rateInfo)
@@ -346,17 +351,15 @@ func (u *Updater) SetDeliveryUploadSpeedLimit(sender dbus.Sender, limitConfig st
 	}
 
 	var rateInfo ratelimit.RateInfo
+	var rateLimit int
 	if speedLimitConfig.SpeedLimitEnabled {
 		limitRate, err := strconv.ParseInt(speedLimitConfig.LimitSpeed, 10, 64)
 		if err != nil {
 			return dbusutil.ToError(err)
 		}
-		rateLimit := int(limitRate)
+		rateLimit = int(limitRate)
 		if rateLimit*1024 < ratelimit.MinRateLimit || rateLimit*1024 > ratelimit.MaxRateLimit {
 			rateLimit = int(ratelimit.DefaultRateLimit) / 1024
-		}
-		if err := ratelimit.SetIPFSUploadRateLimit(rateLimit); err != nil {
-			return dbusutil.ToError(err)
 		}
 		rateInfo = ratelimit.RateInfo{
 			LimitType:   ratelimit.RateLimitTypeLocal,
@@ -364,14 +367,21 @@ func (u *Updater) SetDeliveryUploadSpeedLimit(sender dbus.Sender, limitConfig st
 			CurrentRate: int64(rateLimit) * 1024,
 		}
 	} else {
-		if err := ratelimit.SetIPFSUploadRateLimit(-1); err != nil {
-			return dbusutil.ToError(err)
-		}
+		rateLimit = -1
 		rateInfo = ratelimit.RateInfo{
 			LimitType:   ratelimit.RateLimitTypeNo,
 			LimitRate:   ratelimit.DefaultRateLimit,
 			CurrentRate: ratelimit.DefaultRateLimit,
 		}
+	}
+
+	// 如果下发的状态与当前状态一致，则不需要重复设置
+	if rateInfo.SameAsConfig(u.config.DeliveryLocalUploadGlobalLimit) {
+		return nil
+	}
+
+	if err := ratelimit.SetIPFSUploadRateLimit(rateLimit); err != nil {
+		return dbusutil.ToError(err)
 	}
 	rateInfoData, err := json.Marshal(rateInfo)
 	if err != nil {


### PR DESCRIPTION
PMS: BUG-367257 BUG-370257

## Summary by Sourcery

Skip redundant delivery speed-limit updates when the configured rate-limit state is unchanged.

Bug Fixes:
- Avoid repeatedly applying delivery download and upload speed limits when the requested state already matches the stored configuration.

Enhancements:
- Add rate-limit state comparison that distinguishes unlimited and local-limit configurations while handling invalid or unsupported stored values safely.

Tests:
- Add coverage for matching, mismatching, invalid, empty, and unsupported rate-limit configurations.