### PR TITLE
feat(dconfig): add deny-exec-whitelist config entry

### DIFF
--- a/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
+++ b/usr/share/dsg/configs/org.deepin.dde.lastore/org.deepin.dde.lastore.json
@@ -713,6 +713,19 @@
       "description": "Delivery local upload off-peak limit",
       "permissions": "readwrite",
       "visibility": "private"
+    },
+    "deny-exec-whitelist": {
+      "value": true,
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "DenyExecWhitelist",
+      "name[zh_CN]": "禁用二进制白名单",
+      "description": "Whether disable determining the caller through the binary path",
+      "description[zh_CN]": "是否禁止通过二进制路径判断调用者",
+      "permissions": "readonly",
+      "visibility": "public"
     }
   }
 }


### PR DESCRIPTION
## What
新增 `deny-exec-whitelist` dsg 配置项，用于控制是否禁用通过二进制路径判断调用者。

## Why
提供开关以决定是否通过二进制路径（可执行文件白名单）判断 D-Bus 调用者身份。默认值 `true`，即默认禁用该判断方式，保持当前行为；需要时可改为 `false` 启用。

## Changes
- 在 `org.deepin.dde.lastore.json` 中新增 `deny-exec-whitelist` 配置项：
  - `name`: `DenyExecWhitelist`
  - `value`: `true`（默认禁用二进制路径判断）
  - `permissions`: `readonly`，`visibility`: `public`
  - 配套中英文 `name`/`description` 本地化字段

## Influence
调用者鉴权相关。

Log: 新增 deny-exec-whitelist 配置项，控制是否禁用通过二进制路径判断调用者

## Summary by Sourcery

New Features:
- Add a public read-only dconfig entry to control whether caller authentication may use executable-path whitelisting, disabled by default.