### PR TITLE
fix(smartmirror): use GET instead of HEAD for mirror connectivity testing

### DIFF
--- a/src/lastore-smartmirror-daemon/header.go
+++ b/src/lastore-smartmirror-daemon/header.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -65,6 +66,7 @@ func makeHeader() map[string]string {
 	return map[string]string{
 		"User-Agent": userAgent(),
 		"MID":        machineID(),
+		"Range":      "bytes=0-1023",
 	}
 }
 
@@ -109,6 +111,9 @@ func handleRequest(r *http.Request) (resultURL string, statusCode int) {
 	if err != nil {
 		return "", -2
 	}
+	// Read and discard a small amount of the body to allow connection reuse.
+	// Limit to 4KB to avoid downloading large files when the server ignores Range.
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	resp.Body.Close()
 
 	switch resp.StatusCode / 100 {

--- a/src/lastore-smartmirror-daemon/smartmirror.go
+++ b/src/lastore-smartmirror-daemon/smartmirror.go
@@ -154,7 +154,7 @@ func (s *SmartMirror) route(original, officialMirror string) string {
 		return s.makeChoice(original, officialMirror)
 	} else if strings.Contains(original, "/dists/") && strings.HasSuffix(original, "Release") {
 		// Get Release from Release
-		url, _ := handleRequest(buildRequest(makeHeader(), "HEAD", original))
+		url, _ := handleRequest(buildRequest(makeHeader(), "GET", original))
 		return url
 	} else if strings.Contains(original, "/dists/") && strings.Contains(original, "/by-hash/") {
 		return s.makeChoice(original, officialMirror)
@@ -179,7 +179,7 @@ func (s *SmartMirror) makeChoice(original, officialMirror string) string {
 		go func(mirror string) {
 			b := time.Now()
 			urlMirror := strings.Replace(original, officialMirror, mirror, 1)
-			v, statusCode := handleRequest(buildRequest(header, "HEAD", urlMirror))
+			v, statusCode := handleRequest(buildRequest(header, "GET", urlMirror))
 			report := Report{
 				Mirror:     mirror,
 				URL:        v,
@@ -232,7 +232,7 @@ func (s *SmartMirror) makeChoice(original, officialMirror string) string {
 		logger.Info("end -----------------------\n")
 		s.mirrorQuality.reportList <- reportList
 		header := makeReportHeader(reportList)
-		handleRequest(buildRequest(header, "HEAD", original))
+		handleRequest(buildRequest(header, "GET", original))
 		close(detectReport)
 	}()
 


### PR DESCRIPTION
PMS: BUG-369443

## Summary by Sourcery

Fix smart mirror connectivity checks by using bounded GET requests instead of HEAD requests.

Bug Fixes:
- Use GET requests instead of HEAD requests when checking smart mirror connectivity and retrieving Release metadata.
- Read and discard a limited portion of GET response bodies to support connection reuse while preventing unnecessary downloads.