### PR TITLE
fix(updater): only mark major upgrade for system updates

### DIFF
--- a/src/lastore-daemon/manager_check.go
+++ b/src/lastore-daemon/manager_check.go
@@ -192,6 +192,16 @@ const (
 	optionFilePathTemp = "/tmp/deepin_update_option.json"
 )
 
+// isMajorUpgradeForMode 判断指定更新模式下是否需要标记为大版本升级。
+// 仅当更新包含系统仓库更新(SystemUpdate)时才根据版本号判断；
+// 若仅为安全更新或三方源更新等非系统更新，则直接返回 false。
+func (m *Manager) isMajorUpgradeForMode(mode system.UpdateType) bool {
+	if mode&system.SystemUpdate == 0 {
+		return false
+	}
+	return m.updatePlatform.IsMajorUpgrade()
+}
+
 func (m *Manager) setRebootCheckOption(mode system.UpdateType, uuid string) error {
 	option := &fullUpgradeOption{
 		DoUpgrade:         false,
@@ -200,7 +210,7 @@ func (m *Manager) setRebootCheckOption(mode system.UpdateType, uuid string) erro
 		PreGreeterCheck:   true,
 		AfterGreeterCheck: true,
 		UUID:              uuid,
-		MajorUpgrade:      m.updatePlatform.IsMajorUpgrade(),
+		MajorUpgrade:      m.isMajorUpgradeForMode(mode),
 	}
 	content, err := json.Marshal(option)
 	if err != nil {

--- a/src/lastore-daemon/manager_ifc.go
+++ b/src/lastore-daemon/manager_ifc.go
@@ -437,7 +437,7 @@ func (m *Manager) PrepareFullScreenUpgrade(sender dbus.Sender, option string) *d
 		opt.DoUpgrade = true
 		opt.PreGreeterCheck = false
 		opt.AfterGreeterCheck = false
-		opt.MajorUpgrade = m.updatePlatform.IsMajorUpgrade()
+		opt.MajorUpgrade = m.isMajorUpgradeForMode(opt.DoUpgradeMode)
 		content, err := json.Marshal(opt)
 		if err != nil {
 			logger.Warning(err)


### PR DESCRIPTION
仅在更新模式包含系统更新时标记 MajorUpgrade，避免安全更新或
三方源更新被误判为大版本升级。

PMS: BUG-375911

## Summary by Sourcery

Bug Fixes:
- Only mark updates as major upgrades when the selected update mode includes system updates, preventing security-only or third-party source updates from being misclassified.