### PR TITLE
fix: use English names for mirror sources in mirrors.json

### DIFF
--- a/var/lib/lastore/mirrors.json
+++ b/var/lib/lastore/mirrors.json
@@ -37,7 +37,7 @@
   },
   {
     "id": "HuaweiCloud",
-    "name": "[CN] 华为云",
+    "name": "[CN] Huawei Cloud",
     "url": "https://mirrors.huaweicloud.com/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 华为云",
@@ -325,7 +325,7 @@
   },
   {
     "id": "sjtu-edu",
-    "name": "上海交通大学",
+    "name": "[CN] Shanghai Jiao Tong University",
     "url": "https://ftp.sjtu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 上海交通大学",
@@ -337,7 +337,7 @@
   },
   {
     "id": "lzu",
-    "name": "兰州大学",
+    "name": "[CN] Lanzhou University",
     "url": "https://mirror.lzu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 兰州大学",
@@ -349,7 +349,7 @@
   },
   {
     "id": "cqu",
-    "name": "重庆大学",
+    "name": "[CN] Chongqing University",
     "url": "https://mirrors.cqu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 重庆大学",
@@ -361,7 +361,7 @@
   },
   {
     "id": "nyist",
-    "name": "南阳理工学院",
+    "name": "[CN] Nanyang Institute of Technology",
     "url": "https://mirror.nyist.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 南阳理工学院",
@@ -373,7 +373,7 @@
   },
   {
     "id": "qlu",
-    "name": "齐鲁工业大学",
+    "name": "[CN] Qilu University of Technology",
     "url": "https://mirrors.qlu.edu.cn/deepin/",
     "name_locale": {
       "zh_CN": "[CN] 齐鲁工业大学",


### PR DESCRIPTION
1. Root cause: 6 mirror sources had Chinese text in the name field, which is used as fallback when locale-specific name is unavailable
2. Fix: changed name field to English for HuaweiCloud, sjtu-edu, lzu, cqu, nyist, and qlu; name_locale zh_CN/zh_TW entries preserved
3. Impact: non-Chinese locales now fall back to English names instead of Chinese

Log: fix mirror source names showing Chinese in non-Chinese locales

Influence:
1. Test mirror source list in English locale shows English names
2. Test zh_CN locale still shows Chinese names (no regression)
3. Test zh_TW locale still shows Traditional Chinese names (no regression)

fix: 修复 mirrors.json 中镜像源 name 字段为中文

1. 根因：6 条镜像源的 name 字段为中文，该字段在 locale 特定名称 不可用时作为 fallback 使用，导致非中文环境 fallback 显示中文
2. 方案：将 HuaweiCloud、sjtu-edu、lzu、cqu、nyist、qlu 的 name 字段改为英文，name_locale 中 zh_CN/zh_TW 条目保持不变
3. 影响：非中文 locale 现 fallback 到英文名称而非中文

Log: 修复非中文环境下镜像源名称显示为中文

Influence:
1. 测试英文环境下镜像源列表显示英文名称
2. 测试 zh_CN 环境下仍显示中文名称（无回归）
3. 测试 zh_TW 环境下仍显示繁体中文名称（无回归）

PMS: BUG-375853

## Summary by Sourcery

Bug Fixes:
- Use English fallback names for six mirror sources so non-Chinese locales no longer display Chinese names.