### PR TITLE
chore: update changelog to 6.2.69

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
 lastore-daemon (6.2.69) unstable; urgency=medium
 
+  * fix: comment out TestGetDiskSize_ReturnsResult (#489)
+  * refactor: make system helpers injectable for tests (#488)
+  * test: fix test failure (#487)
+  * test: improve unit test coverage for lastore-daemon (#486)
   * test: improve unit test coverage for lastore-daemon (#483)
   * fix: use English names for mirror sources in mirrors.json
   * fix(updater): only mark major upgrade for system updates

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+lastore-daemon (6.2.69) unstable; urgency=medium
+
+  * test: improve unit test coverage for lastore-daemon (#483)
+  * fix: use English names for mirror sources in mirrors.json
+  * fix(updater): only mark major upgrade for system updates
+  * fix(smartmirror): use GET instead of HEAD for mirror connectivity
+    testing
+
+ -- wangzhaohui <wangzhaohui@uniontech.com>  Fri, 04 Sep 2026 11:13:28 +0800
+
 lastore-daemon (6.2.68) unstable; urgency=medium
 
   * feat(dconfig): add deny-exec-whitelist config entry (#477)


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.2.69

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.2.69
- 目标分支: master

## Summary by Sourcery

Chores:
- Update the Debian changelog for release 6.2.69.