### PR TITLE
refactor: make system helpers injectable for tests

### DIFF
--- a/src/internal/dstore/dstore.go
+++ b/src/internal/dstore/dstore.go
@@ -39,6 +39,11 @@ func NewStore() *Store {
 	return s
 }
 
+// NewStoreWithConfig 返回使用给定 ini 配置的 Store，主要用于测试以及已持有 *ini.File 的调用方。
+func NewStoreWithConfig(cfg *ini.File) *Store {
+	return &Store{sysCfg: cfg}
+}
+
 func (s *Store) GetMetadataServer() (string, error) {
 	var metadataServer string
 	if s.sysCfg != nil {

--- a/src/internal/system/common.go
+++ b/src/internal/system/common.go
@@ -302,8 +302,12 @@ func CheckLock(p string) (string, bool) {
 }
 
 func getEditionName() (string, error) {
+	return getEditionNameFromFile("/etc/os-version")
+}
+
+func getEditionNameFromFile(path string) (string, error) {
 	kf := keyfile.NewKeyFile()
-	err := kf.LoadFromFile("/etc/os-version")
+	err := kf.LoadFromFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/src/internal/system/common_extra_test.go
+++ b/src/internal/system/common_extra_test.go
@@ -5,14 +5,19 @@
 package system
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetEditionName(t *testing.T) {
-	// /etc/os-version should exist and be readable in the test environment
-	edition, err := getEditionName()
+	path := filepath.Join(t.TempDir(), "os-version")
+	require.NoError(t, os.WriteFile(path, []byte("[Version]\nEditionName=Community\n"), 0644))
+
+	edition, err := getEditionNameFromFile(path)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, edition)
+	assert.Equal(t, "Community", edition)
 }

--- a/src/internal/system/coverage_extra_test.go
+++ b/src/internal/system/coverage_extra_test.go
@@ -93,17 +93,42 @@ func TestQueryPackageInstalledExtra(t *testing.T) {
 	assert.False(t, QueryPackageInstalled("definitely-not-installed-pkg-xyz123"))
 }
 
+func newFakeAptCache(t *testing.T) string {
+	t.Helper()
+	script := `#!/bin/sh
+# argv: -c <conf> show|policy -- <pkgId>
+sub="$3"
+pkg="$5"
+case "$sub" in
+show)
+	case "$pkg" in
+	installable|none-candidate) exit 0 ;;
+	*) exit 1 ;;
+	esac
+	;;
+policy)
+	case "$pkg" in
+	installable) echo "Candidate: 1.0" ;;
+	none-candidate) echo "Candidate: (none)" ;;
+	*) exit 1 ;;
+	esac
+	;;
+esac
+`
+	path := filepath.Join(t.TempDir(), "apt-cache")
+	require.NoError(t, os.WriteFile(path, []byte(script), 0755))
+	return path
+}
+
 func TestQueryPackageInstallableExtra(t *testing.T) {
-	assert.True(t, QueryPackageInstallable("dpkg"))
-	assert.False(t, QueryPackageInstallable("definitely-not-installed-pkg-xyz123"))
+	bin := newFakeAptCache(t)
+	assert.True(t, queryPackageInstallable(bin, "/nonexistent.conf", "installable"))
+	assert.False(t, queryPackageInstallable(bin, "/nonexistent.conf", "missing"))
 }
 
 func TestQueryPackageInstallableNoCandidateExtra(t *testing.T) {
-	// "tigerbeetle" is left in config-files state on this system; apt-cache
-	// show succeeds but policy reports "Candidate: (none)" in C locale.
-	t.Setenv("LANG", "C.UTF-8")
-	t.Setenv("LC_ALL", "C.UTF-8")
-	assert.False(t, QueryPackageInstallable("tigerbeetle"))
+	bin := newFakeAptCache(t)
+	assert.False(t, queryPackageInstallable(bin, "/nonexistent.conf", "none-candidate"))
 }
 
 func TestQueryPackageDownloadSizeEmptyExtra(t *testing.T) {

--- a/src/internal/system/system_apt.go
+++ b/src/internal/system/system_apt.go
@@ -268,12 +268,16 @@ func QueryPackageInstalled(pkgId string) bool {
 
 // QueryPackageInstallable query whether the pkgId can be installed
 func QueryPackageInstallable(pkgId string) bool {
-	err := exec.Command("/usr/bin/apt-cache", "-c", LastoreAptV2CommonConfPath, "show", "--", pkgId).Run() // #nosec G204
+	return queryPackageInstallable("/usr/bin/apt-cache", LastoreAptV2CommonConfPath, pkgId)
+}
+
+func queryPackageInstallable(bin, confPath, pkgId string) bool {
+	err := exec.Command(bin, "-c", confPath, "show", "--", pkgId).Run() // #nosec G204
 	if err != nil {
 		return false
 	}
 
-	out, err := exec.Command("/usr/bin/apt-cache", "-c", LastoreAptV2CommonConfPath, "policy", "--", pkgId).CombinedOutput() // #nosec G204
+	out, err := exec.Command(bin, "-c", confPath, "policy", "--", pkgId).CombinedOutput() // #nosec G204
 	if err != nil {
 		return false
 	}

--- a/src/internal/system/update_type.go
+++ b/src/internal/system/update_type.go
@@ -579,15 +579,13 @@ func CustomSourceWrapper(updateType UpdateType, doRealAction func(path string, u
 			}()
 			var allSourceFilePaths []string
 			for _, path := range sourcePathList {
-				var fileInfo os.FileInfo
-				fileInfo, beforeDoRealErr = os.Stat(path)
-				if beforeDoRealErr != nil {
+				fileInfo, err := os.Stat(path)
+				if err != nil {
 					continue
 				}
 				if fileInfo.IsDir() {
-					var allSourceDirFileInfos []os.DirEntry
-					allSourceDirFileInfos, beforeDoRealErr = os.ReadDir(path)
-					if beforeDoRealErr != nil {
+					allSourceDirFileInfos, err := os.ReadDir(path)
+					if err != nil {
 						continue
 					}
 					for _, fileInfo := range allSourceDirFileInfos {

--- a/src/internal/utils/fixme/pkg_recommend/lang_info.go
+++ b/src/internal/utils/fixme/pkg_recommend/lang_info.go
@@ -29,7 +29,7 @@ type LangCodeInfo struct {
 	Variant     string
 }
 
-const (
+var (
 	LangInfoFile = "/usr/share/i18n/language_info.json"
 
 	langSupportedFile = "/usr/share/i18n/SUPPORTED"

--- a/src/internal/utils/fixme/pkg_recommend/lang_info_extra_test.go
+++ b/src/internal/utils/fixme/pkg_recommend/lang_info_extra_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestIsSupportedLocaleTrue(t *testing.T) {
-	// en_US.UTF-8 should be in /usr/share/i18n/SUPPORTED on most systems
+	useTestDataPaths(t)
+	// en_US.UTF-8 should be in the bundled SUPPORTED testdata
 	assert.True(t, IsSupportedLocale("en_US.UTF-8"))
 }
 
@@ -22,6 +23,7 @@ func TestIsSupportedLocaleFalse(t *testing.T) {
 }
 
 func TestGetSupportedLangInfos(t *testing.T) {
+	useTestDataPaths(t)
 	infos, err := GetSupportedLangInfos()
 	assert.NoError(t, err)
 	// Should return at least some entries on a system with i18n data

--- a/src/internal/utils/fixme/pkg_recommend/paths_test.go
+++ b/src/internal/utils/fixme/pkg_recommend/paths_test.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package pkg_recommend
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// useTestDataPaths 把 i18n 数据文件路径切换到仓库内置的测试数据，
+// 使测试不依赖构建环境中的 /usr/share/i18n 数据文件。
+func useTestDataPaths(t *testing.T) {
+	t.Helper()
+
+	origLangInfo := LangInfoFile
+	origSupported := langSupportedFile
+	origDepends := pkgDependsFile
+
+	LangInfoFile = filepath.Join("testdata", "support_languages.json")
+	langSupportedFile = filepath.Join("testdata", "SUPPORTED")
+	pkgDependsFile = filepath.Join("pkg_depends.json")
+
+	t.Cleanup(func() {
+		LangInfoFile = origLangInfo
+		langSupportedFile = origSupported
+		pkgDependsFile = origDepends
+	})
+}

--- a/src/internal/utils/fixme/pkg_recommend/pkg_depends.go
+++ b/src/internal/utils/fixme/pkg_recommend/pkg_depends.go
@@ -10,7 +10,7 @@ type DependentInfo struct {
 }
 type DependentInfos []DependentInfo
 
-const (
+var (
 	pkgDependsFile = "/usr/share/i18n/i18n_dependent.json"
 )
 

--- a/src/internal/utils/fixme/pkg_recommend/pkg_depends_extra_test.go
+++ b/src/internal/utils/fixme/pkg_recommend/pkg_depends_extra_test.go
@@ -22,6 +22,7 @@ func TestGetEnhancedLocalePackagesInvalidLocale(t *testing.T) {
 }
 
 func TestGetByPackage(t *testing.T) {
+	useTestDataPaths(t)
 	pkgs, conflicts, err := GetByPackage("zh_CN.UTF-8", "gvfs")
 	assert.NoError(t, err)
 	_ = pkgs
@@ -29,11 +30,13 @@ func TestGetByPackage(t *testing.T) {
 }
 
 func TestGetByPackageInvalidLocale(t *testing.T) {
+	useTestDataPaths(t)
 	_, _, err := GetByPackage("xx_XX.INVALID", "gvfs")
 	assert.NoError(t, err)
 }
 
 func TestGetByLocale(t *testing.T) {
+	useTestDataPaths(t)
 	infos, conflicts, err := GetByLocale("zh_CN.UTF-8")
 	assert.NoError(t, err)
 	_ = infos
@@ -41,6 +44,7 @@ func TestGetByLocale(t *testing.T) {
 }
 
 func TestGetByLocaleInvalidLocale(t *testing.T) {
+	useTestDataPaths(t)
 	infos, conflicts, err := GetByLocale("xx_XX.INVALID")
 	assert.NoError(t, err)
 	// With invalid locale, infos should be empty (no matching lang code)

--- a/src/lastore-daemon/manager_update_extra_test.go
+++ b/src/lastore-daemon/manager_update_extra_test.go
@@ -5,12 +5,23 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
-	"github.com/stretchr/testify/assert"
+	"os"
 	"os/exec"
 	"strconv"
 	"testing"
+
+	"github.com/linuxdeepin/lastore-daemon/src/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func newTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	tmpfile, err := os.CreateTemp(t.TempDir(), "config-*.json")
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
+	return config.NewConfig(tmpfile.Name())
+}
 
 func TestCompareVersionsGeFast(t *testing.T) {
 	tests := []struct {
@@ -136,7 +147,7 @@ func TestCompareVersionLt(t *testing.T) {
 }
 
 func TestDisableOnlineSpeedLimitConfig_AlreadyDisabled(t *testing.T) {
-	m := &Manager{config: config.NewConfig("")}
+	m := &Manager{config: newTestConfig(t)}
 	cfg := downloadSpeedLimitConfig{
 		DownloadSpeedLimitEnabled: false,
 		LimitSpeed:                "1024",
@@ -153,7 +164,7 @@ func TestDisableOnlineSpeedLimitConfig_AlreadyDisabled(t *testing.T) {
 }
 
 func TestDisableOnlineSpeedLimitConfig_Enabled(t *testing.T) {
-	m := &Manager{config: config.NewConfig("")}
+	m := &Manager{config: newTestConfig(t)}
 	cfg := downloadSpeedLimitConfig{
 		DownloadSpeedLimitEnabled: true,
 		LimitSpeed:                "2048",
@@ -172,7 +183,7 @@ func TestDisableOnlineSpeedLimitConfig_Enabled(t *testing.T) {
 }
 
 func TestDisableOnlineSpeedLimitConfig_InvalidJSON(t *testing.T) {
-	m := &Manager{config: config.NewConfig("")}
+	m := &Manager{config: newTestConfig(t)}
 	m.config.SetDownloadSpeedLimitConfig("invalid-json")
 
 	err := m.disableOnlineSpeedLimitConfig()

--- a/src/lastore-tools/category.go
+++ b/src/lastore-tools/category.go
@@ -47,17 +47,14 @@ func genApplications(v []*dstore.PackageInfo, fpath string) error {
 // GenerateApplications 在 fpath 路径生成 applications.json 文件，此文件内容为上架应用的信息。
 // fpath 一般为/var/lib/lastore/applications.json 。
 func GenerateApplications(repo, fpath string) error {
-	s := dstore.NewStore()
+	return generateApplications(dstore.NewStore(), fpath)
+}
 
+func generateApplications(s *dstore.Store, fpath string) error {
 	list, err := s.GetPackageApplication(fpath)
 	if err != nil {
 		return err
 	}
 
-	err = genApplications(list, fpath)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return genApplications(list, fpath)
 }

--- a/src/lastore-tools/category_extra_test.go
+++ b/src/lastore-tools/category_extra_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-ini/ini"
 	"github.com/linuxdeepin/lastore-daemon/src/internal/dstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,7 +67,6 @@ func TestGenApplications(t *testing.T) {
 	assert.Contains(t, string(data), "测试应用")
 	assert.Contains(t, string(data), "simple")
 }
-
 func TestGenerateApplications(t *testing.T) {
 	dir := t.TempDir()
 	fpath := filepath.Join(dir, "apps.json")
@@ -75,7 +75,8 @@ func TestGenerateApplications(t *testing.T) {
 	cacheContent := `{"dpk://deb/testapp":{"name":"Test","category":"graphics","package_name":"testapp","locale":{"zh_CN":{"description":{"name":"测试应用"}}}}}`
 	require.NoError(t, os.WriteFile(fpath+".cache.json", []byte(cacheContent), 0644))
 
-	err := GenerateApplications("repo", fpath)
+	s := newTestStore(t)
+	err := generateApplications(s, fpath)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(fpath)
@@ -95,6 +96,19 @@ func TestGenerateApplicationsWriteError(t *testing.T) {
 	cacheContent := `{"dpk://deb/testapp":{"name":"Test","category":"graphics","package_name":"testapp","locale":{}}}`
 	require.NoError(t, os.WriteFile(fpath+".cache.json", []byte(cacheContent), 0644))
 
-	err := GenerateApplications("repo", fpath)
+	s := newTestStore(t)
+	err := generateApplications(s, fpath)
 	assert.Error(t, err)
+}
+
+func newTestStore(t *testing.T) *dstore.Store {
+	t.Helper()
+
+	f := ini.Empty()
+	sec, err := f.NewSection("General")
+	require.NoError(t, err)
+	_, err = sec.NewKey("Server", "https://metadata.example.com")
+	require.NoError(t, err)
+
+	return dstore.NewStoreWithConfig(f)
 }


### PR DESCRIPTION
Extract getEditionNameFromFile and queryPackageInstallable with injectable
paths and binaries; rework tests to use temp dirs, fake apt-cache and temp
config.

拆分getEditionNameFromFile和queryPackageInstallable支持路径与二进制注入，
测试改用临时目录、伪apt-cache与临时配置。

Log: 重构系统辅助函数以支持依赖注入，提升可测试性
Influence: 仅内部实现与测试调整，不改变对外行为。

## Summary by Sourcery

Refactor internal helpers and tests to remove dependencies on host system files, commands, and configuration.

Enhancements:
- Make system, data-store, application-generation, and locale helpers configurable through injectable files, binaries, and store instances without changing public behavior.

Tests:
- Replace environment-dependent tests with isolated temporary files, configurations, fake apt-cache commands, and bundled locale test data.

Chores:
- Simplify local error handling in update source traversal.